### PR TITLE
feat: implemented native support for Fusion

### DIFF
--- a/src/Components/StoryControls.lua
+++ b/src/Components/StoryControls.lua
@@ -25,6 +25,10 @@ local function StoryControls(props: Props)
 		end
 
 		local option
+		if typeof(value) == "table" and value.type == "State" then
+			value = value:get()
+		end
+
 		if typeof(value) == "boolean" then
 			option = React.createElement(Checkbox, {
 				initialState = value,

--- a/src/Components/StoryView.lua
+++ b/src/Components/StoryView.lua
@@ -40,12 +40,17 @@ local function StoryView(props: Props)
 	local showControls = controls and not Sift.isEmpty(controls)
 
 	local setControl = React.useCallback(function(control: string, newValue: any)
-		setExtraControls(function(prev)
-			return Sift.Dictionary.merge(prev, {
-				[control] = newValue,
-			})
-		end)
-	end, {})
+		if story and story.fusion then
+			local thisControl = controls[control]
+			thisControl:set(newValue)
+		else
+			setExtraControls(function(prev)
+				return Sift.Dictionary.merge(prev, {
+					[control] = newValue,
+				})
+			end)
+		end
+	end, { extraControls, story })
 
 	local viewCode = React.useCallback(function()
 		Selection:Set({ props.story })

--- a/src/Hooks/useStory.lua
+++ b/src/Hooks/useStory.lua
@@ -13,6 +13,14 @@ local function useStory(module: ModuleScript, storybook: types.Storybook, loader
 	local loadStory = React.useCallback(function()
 		local story, err = loadStoryModule(loader, module, storybook)
 
+		if story and story.controls and story.fusion then
+			local newControls = {}
+			for k, v in story.controls do
+				newControls[k] = story.fusion.Value(v)
+			end
+			story.controls = newControls
+		end
+
 		setState({
 			story = story,
 			err = err,

--- a/src/Story/loadStoryModule.lua
+++ b/src/Story/loadStoryModule.lua
@@ -37,6 +37,7 @@ local function loadStoryModule(loader: any, module: ModuleScript, storybook: typ
 				react = storybook.react,
 				reactRoblox = storybook.reactRoblox,
 				roact = storybook.roact,
+				fusion = storybook.fusion,
 			}, result)
 		else
 			return nil, Errors.Generic:format(module:GetFullName(), message)

--- a/src/types.lua
+++ b/src/types.lua
@@ -73,6 +73,7 @@ types.StoryMeta = t.interface({
 	roact = t.optional(types.Roact),
 	react = t.optional(types.React),
 	reactRoblox = t.optional(types.ReactRoblox),
+	fusion = t.optional(t.any),
 })
 
 export type RoactStory = StoryMeta & {
@@ -127,5 +128,51 @@ export type ComponentTreeNode = {
 }
 
 export type DragHandle = "Top" | "Right" | "Bottom" | "Left"
+
+-- Fusion Types
+-- https://github.com/Elttob/Fusion
+export type SpecialKey = {
+	type: "SpecialKey",
+	kind: string,
+	stage: "self" | "descendants" | "ancestor" | "observer",
+	apply: (SpecialKey, value: any, applyTo: Instance, cleanupTasks: { Task }) -> (),
+}
+
+export type Task =
+	Instance
+	| RBXScriptConnection
+	| () -> () | { destroy: (any) -> () } | { Destroy: (any) -> () } | { Task }
+
+export type PropertyTable = { [string | SpecialKey]: any }
+type Set<T> = { [T]: any }
+
+export type Dependency = {
+	dependentSet: Set<Dependent>,
+}
+
+export type Dependent = {
+	update: (Dependent) -> boolean,
+	dependencySet: Set<Dependency>,
+}
+
+export type StateObject<T> = Dependency & {
+	type: "State",
+	kind: string,
+}
+
+export type Value<T> = StateObject<T> & {
+	kind: "State",
+	set: (Value<T>, newValue: any, force: boolean?) -> (),
+}
+
+export type Fusion = {
+	New: (className: string) -> ((propertyTable: PropertyTable) -> Instance),
+	Value: <T>(initialValue: T) -> Value<T>,
+}
+
+types.Fusion = t.interface({
+	New = t.callback,
+	Value = t.callback,
+})
 
 return types


### PR DESCRIPTION
# Problem

flipbook didn't have support for Fusion natively. Even though it did work, it didn't work the correct way using their state objects ``Fusion.Value``.

# Solution

Allow uses to now pass in a ``fusion`` property into their storybook. If this happens, we modify the controls table in ``useStory`` to convert all the values to be wrapped in ``Fusion.Value``

# Checklist

- [ ] Ran `./bin/test.sh` locally before merging
