### PR TITLE
Fix Documentation & Contributing Guide links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can install flipbook from the [Roblox marketplace](https://www.roblox.com/li
 
 ## Documentation
 
-Learn how to use flipbook on the [documentation site](https://vocksel.github.io/flipbook).
+Learn how to use flipbook on the [documentation site](https://flipbook-labs.github.io/flipbook/).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Learn how to use flipbook on the [documentation site](https://flipbook-labs.gith
 
 ## Contributing
 
-Before opening a pull request, check out our [contributing guide](https://vocksel.github.io/flipbook/docs/contributing) to learn how we develop the plugin.
+Before opening a pull request, check out our [contributing guide](https://flipbook-labs.github.io/flipbook/docs/contributing/) to learn how we develop the plugin.
 
 ## License
 


### PR DESCRIPTION
Documentation links to https://flipbook-labs.github.io/flipbook/ instead of https://vocksel.github.io/flipbook

# Problem
[#215](https://github.com/flipbook-labs/flipbook/issues/215)
Contributing Guide links to [this 404 page](https://vocksel.github.io/flipbook/docs/contributing)

# Solution
Change the Documentation link in README.md to https://flipbook-labs.github.io/flipbook/
Change the Contributing Guide link in README.md to https://flipbook-labs.github.io/flipbook/docs/contributing/

# Checklist

- [X] Ran `./bin/test.sh` locally before merging
