### PR TITLE
Fix links

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ on:
     types: [published]
 
 env:
-  REPO_URL: github.com/vocksel/flipbook
+  REPO_URL: github.com/flipbook-labs/flipbook
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # <img src="img/flipbook.png" alt="Plugin icon" height="32" /> flipbook
 
 [![Install](https://img.shields.io/badge/install-Roblox%20Marketplace-informational)](https://www.roblox.com/library/8517129161)
-[![Docs](https://img.shields.io/badge/learn-Documentation-brightgreen)](https://vocksel.github.io/flipbook)
+[![Docs](https://img.shields.io/badge/learn-Documentation-brightgreen)](https://flipbook-labs.github.io/flipbook)
 [![Discussion](https://img.shields.io/badge/discussion-DevForum-brightgreen)](https://devforum.roblox.com/t/flipbook-%E2%80%94-storybook-plugin-for-roblox-ui/2184387)
-[![CI](https://github.com/vocksel/flipbook/actions/workflows/ci.yml/badge.svg)](https://github.com/vocksel/flipbook/actions/workflows/ci.yml)
+[![CI](https://github.com/flipbook-labs/flipbook/actions/workflows/ci.yml/badge.svg)](https://github.com/flipbook-labs/flipbook/actions/workflows/ci.yml)
 
 
 flipbook is a storybook plugin that previews UI components in a sandboxed environment. With it you can isolate distinct parts of your game's UI to hammer out edge cases and complex states without having to run through the whole UI.
@@ -14,15 +14,15 @@ With native support for popular UI libraries like [Roact](https://github.com/rob
 
 ## Installation
 
-You can install flipbook from the [Roblox marketplace](https://www.roblox.com/library/8517129161) or from the [GitHub releases](https://github.com/vocksel/flipbook/releases) page.
+You can install flipbook from the [Roblox marketplace](https://www.roblox.com/library/8517129161) or from the [GitHub releases](https://github.com/flipbook-labs/flipbook/releases) page.
 
 ## Documentation
 
-Learn how to use flipbook on the [documentation site](https://vocksel.github.io/flipbook).
+Learn how to use flipbook on the [documentation site](https://flipbook-labs.github.io/flipbook).
 
 ## Contributing
 
-Before opening a pull request, check out our [contributing guide](https://vocksel.github.io/flipbook/docs/contributing) to learn how we develop the plugin.
+Before opening a pull request, check out our [contributing guide](https://flipbook-labs.github.io/flipbook/docs/contributing) to learn how we develop the plugin.
 
 ## License
 

--- a/wally.toml
+++ b/wally.toml
@@ -1,5 +1,5 @@
 [package]
-name = "vocksel/flipbook"
+name = "flipbook-labs/flipbook"
 version = "1.5.0"
 license = "MIT"
 registry = "https://github.com/UpliftGames/wally-index"


### PR DESCRIPTION
# Problem

Several links still point to flipbook on my user account, which no longer resolves after moving the repo to the flipbook-labs org

# Solution

I took a pass for every use of `vocksel` and switched it to `flipbook-labs`. Only one I left was for the ModuleLoader dependency, which is resolved by #214 

Closes #215 

# Checklist

- [ ] Ran `./bin/test.sh` locally before merging
