### PR TITLE
Support case-insensitive story searching

### DIFF
--- a/foreman.toml
+++ b/foreman.toml
@@ -1,5 +1,6 @@
 [tools]
 rojo = { source = "rojo-rbx/rojo", version = "7.2.1" }
+run-in-roblox = { source = "rojo-rbx/run-in-roblox", version = "0.3.0" }
 selene = { source = "kampfkarren/selene", version = "0.25.0" }
 stylua = { source = "JohnnyMorganz/StyLua", version = "0.17.1" }
 tarmac = { source = "Roblox/tarmac", version = "0.7.0" }

--- a/src/Components/ComponentTree/Component/init.lua
+++ b/src/Components/ComponentTree/Component/init.lua
@@ -58,7 +58,7 @@ local function Component(props: Props)
 	end
 
 	if props.filter and props.node.icon ~= "storybook" then
-		local match = props.node.name:match(props.filter)
+		local match = props.node.name:lower():match(props.filter:lower())
 
 		if not match then
 			return


### PR DESCRIPTION
# Problem

When using the searchbar you have to account for casing

# Solution

Now when filtering out items from the tree view, the name and filter are converted to lowercase so that case no longer matters

Closes #210

# Checklist

- [ ] Ran `./bin/test.sh` locally before merging
