### PR TITLE
Center searchbar elements

### DIFF
--- a/src/Components/Searchbar.lua
+++ b/src/Components/Searchbar.lua
@@ -79,6 +79,7 @@ local function Searchbar(props: Props)
 		Layout = e("UIListLayout", {
 			SortOrder = Enum.SortOrder.LayoutOrder,
 			FillDirection = Enum.FillDirection.Horizontal,
+			VerticalAlignment = Enum.VerticalAlignment.Center,
 		}),
 
 		InputFieldWrapper = e("Frame", {


### PR DESCRIPTION
# Problem

It was reported in #211 that the searchbar icon is offcenter

# Solution

Super quick one-liner to fix this :) Closes #211

# Checklist

- [ ] Ran `./bin/test.sh` locally before merging
