### PR TITLE
Use DataModel analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Generate sourcemap for LSP
         shell: bash
-        run: rojo sourcemap dev.project.json -o sourcemap.json
+        run: rojo sourcemap tests.project.json -o sourcemap.json
 
       - name: Analyze
         shell: bash

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "luau-lsp.sourcemap.rojoProjectFile": "tests.project.json"
+}

--- a/bin/analyze.sh
+++ b/bin/analyze.sh
@@ -2,7 +2,7 @@
 
 curl -s -O https://raw.githubusercontent.com/JohnnyMorganz/luau-lsp/master/scripts/globalTypes.d.lua
 
-rojo sourcemap dev.project.json -o sourcemap.json
+rojo sourcemap tests.project.json -o sourcemap.json
 
 luau-lsp analyze --sourcemap=sourcemap.json --defs=globalTypes.d.lua --defs=testez.d.lua --ignore=**/_Index/** src/
 

--- a/src/Components/ComponentTree/Component/Directory.lua
+++ b/src/Components/ComponentTree/Component/Directory.lua
@@ -21,7 +21,7 @@ type Props = {
 local function Directory(props: Props)
 	local theme = useTheme()
 	local hover, setHover = React.useState(false)
-	local styles = RoactSpring.useSpring({
+	local styles = (RoactSpring.useSpring :: any)({
 		alpha = if hover then 0 else 1,
 		rotation = if props.expanded then 90 else 0,
 		config = constants.SPRING_CONFIG,

--- a/src/Components/ComponentTree/Component/Story.lua
+++ b/src/Components/ComponentTree/Component/Story.lua
@@ -20,7 +20,7 @@ type Props = {
 local function Story(props: Props)
 	local theme = useTheme()
 	local hover, setHover = React.useState(false)
-	local styles = RoactSpring.useSpring({
+	local styles = (RoactSpring.useSpring :: any)({
 		alpha = if not props.active then if hover then 0 else 1 else 0,
 		color = if not props.active then theme.divider else theme.selection,
 		textColor = if not props.active then theme.textFaded else theme.background,

--- a/src/Components/DragHandle.lua
+++ b/src/Components/DragHandle.lua
@@ -25,7 +25,7 @@ local function DragHandle(props: Props)
 	local plugin = React.useContext(PluginContext.Context)
 	local isDragging, setIsDragging = React.useState(false)
 	local isHovered, setIsHovered = React.useState(false)
-	local mouseInput: InputObject, setMouseInput = React.useState(nil)
+	local mouseInput, setMouseInput = React.useState(nil :: InputObject?)
 
 	local getHandleProperties = React.useCallback(function()
 		local size: UDim2

--- a/src/Components/Navbar/Item.lua
+++ b/src/Components/Navbar/Item.lua
@@ -19,7 +19,7 @@ local function Item(props: Props)
 	local theme = useTheme()
 
 	local hover, setHover = React.useState(false)
-	local styles = RoactSpring.useSpring({
+	local styles = (RoactSpring.useSpring :: any)({
 		alpha = if not props.active and hover then 0 else 1,
 		config = constants.SPRING_CONFIG,
 	})

--- a/src/Components/ResizablePanel.lua
+++ b/src/Components/ResizablePanel.lua
@@ -36,11 +36,17 @@ local function ResizablePanel(props: Props)
 	end, { absoluteSize })
 
 	local isWidthResizable = React.useMemo(function()
-		return Sift.Array.includes(props.dragHandles, "Left") or Sift.Array.includes(props.dragHandles, "Right")
+		if props.dragHandles then
+			return Sift.Array.includes(props.dragHandles, "Left") or Sift.Array.includes(props.dragHandles, "Right")
+		end
+		return nil
 	end, { props.dragHandles })
 
 	local isHeightResizable = React.useMemo(function()
-		return Sift.Array.includes(props.dragHandles, "Top") or Sift.Array.includes(props.dragHandles, "Bottom")
+		if props.dragHandles then
+			return Sift.Array.includes(props.dragHandles, "Top") or Sift.Array.includes(props.dragHandles, "Bottom")
+		end
+		return nil
 	end, { props.dragHandles })
 
 	local width = React.useMemo(function()

--- a/src/Components/Searchbar.lua
+++ b/src/Components/Searchbar.lua
@@ -31,7 +31,7 @@ local function Searchbar(props: Props)
 	local isFocused, setIsFocused = React.useState(false)
 	local isExpanded = isFocused or search ~= ""
 
-	local styles = RoactSpring.useSpring({
+	local styles = (RoactSpring.useSpring :: any)({
 		alpha = if isExpanded then 1 else 0,
 		config = constants.SPRING_CONFIG,
 	})

--- a/src/Components/StoryView.lua
+++ b/src/Components/StoryView.lua
@@ -34,7 +34,7 @@ local function StoryView(props: Props)
 	local extraControls, setExtraControls = React.useState({})
 	local controlsHeight, setControlsHeight = React.useState(constants.CONTROLS_INITIAL_HEIGHT)
 	local topbarHeight, setTopbarHeight = React.useState(0)
-	local storyParentRef = React.useRef()
+	local storyParentRef = React.useRef(nil :: GuiObject?)
 	local controls
 
 	if story and story.controls then

--- a/src/Plugin/PluginContext.lua
+++ b/src/Plugin/PluginContext.lua
@@ -2,7 +2,7 @@ local flipbook = script:FindFirstAncestor("flipbook")
 
 local React = require(flipbook.Packages.React)
 
-local PluginContext = React.createContext({})
+local PluginContext = React.createContext(nil :: Plugin?)
 
 export type Props = {
 	plugin: Plugin,

--- a/src/Plugin/PluginContext.lua
+++ b/src/Plugin/PluginContext.lua
@@ -2,7 +2,7 @@ local flipbook = script:FindFirstAncestor("flipbook")
 
 local React = require(flipbook.Packages.React)
 
-local PluginContext = React.createContext()
+local PluginContext = React.createContext({})
 
 export type Props = {
 	plugin: Plugin,


### PR DESCRIPTION
For some reason, using `tests.project.json` gives better analysis that `dev.project.json`. Seems like this is because the former will mount flipbook to the DataModel.

This PR updates our analysis to generate sourcemaps from `tests.project.json`, and also fixes up the resulting type errors from this change
