### PR TITLE
Fix Searchbar filtering

### DIFF
--- a/src/Components/ComponentTree/Component/init.lua
+++ b/src/Components/ComponentTree/Component/init.lua
@@ -5,6 +5,7 @@ local Sift = require(flipbook.Packages.Sift)
 local Directory = require(script.Directory)
 local Story = require(script.Story)
 local types = require(flipbook.types)
+local getTreeDescendants = require(flipbook.Modules.getTreeDescendants)
 
 local e = React.createElement
 
@@ -57,10 +58,20 @@ local function Component(props: Props)
 		end
 	end
 
-	if props.filter and props.node.icon ~= "storybook" then
-		local match = props.node.name:lower():match(props.filter:lower())
+	if props.filter then
+		if props.node.icon == "story" and not props.node.name:lower():match(props.filter:lower()) then
+			return
+		end
 
-		if not match then
+		local isEmpty = true
+		for _, descendant in ipairs(getTreeDescendants(props.node)) do
+			if descendant.name:lower():match(props.filter:lower()) then
+				isEmpty = false
+				break
+			end
+		end
+
+		if isEmpty then
 			return
 		end
 	end

--- a/src/Components/ComponentTree/Component/init.lua
+++ b/src/Components/ComponentTree/Component/init.lua
@@ -64,7 +64,7 @@ local function Component(props: Props)
 		end
 
 		local isEmpty = true
-		for _, descendant in ipairs(getTreeDescendants(props.node)) do
+		for _, descendant in getTreeDescendants(props.node) do
 			if descendant.name:lower():match(props.filter:lower()) then
 				isEmpty = false
 				break

--- a/src/Modules/getTreeDescendants.lua
+++ b/src/Modules/getTreeDescendants.lua
@@ -1,0 +1,23 @@
+local flipbook = script:FindFirstAncestor("flipbook")
+
+local types = require(flipbook.types)
+
+local function getTreeDescendants(root: types.ComponentTreeNode): { types.ComponentTreeNode }
+	local descendants: { types.ComponentTreeNode } = {}
+
+	local function traverse(node: types.ComponentTreeNode, isRoot: boolean)
+		if not isRoot then
+			table.insert(descendants, node)
+		end
+
+		for _, child in ipairs(node.children) do
+			traverse(child, false)
+		end
+	end
+
+	traverse(root, true)
+
+	return descendants
+end
+
+return getTreeDescendants

--- a/src/Modules/getTreeDescendants.lua
+++ b/src/Modules/getTreeDescendants.lua
@@ -10,7 +10,7 @@ local function getTreeDescendants(root: types.ComponentTreeNode): { types.Compon
 			table.insert(descendants, node)
 		end
 
-		for _, child in ipairs(node.children) do
+		for _, child in node.children do
 			traverse(child, false)
 		end
 	end

--- a/src/Modules/getTreeDescendants.spec.lua
+++ b/src/Modules/getTreeDescendants.spec.lua
@@ -1,0 +1,31 @@
+return function()
+	local getTreeDescendants = require(script.Parent.getTreeDescendants)
+
+	it("should return an empty table when the root has no children", function()
+		local root = { name = "root", children = {} }
+
+		local result = getTreeDescendants(root)
+		expect(result).to.be.a("table")
+		expect(#result).to.equal(0)
+	end)
+
+	it("should return a table with all descendants when the root has children", function()
+		local child1 = { name = "child1", children = {} }
+		local child2 = { name = "child2", children = {} }
+		local root = { name = "root", children = { child1, child2 } }
+
+		local result = getTreeDescendants(root)
+		expect(result).to.be.a("table")
+		expect(#result).to.equal(2)
+	end)
+
+	it("should return a table with all descendants when the tree has multiple levels", function()
+		local grandchild = { name = "grandchild", children = {} }
+		local child = { name = "child", children = { grandchild } }
+		local root = { name = "root", children = { child } }
+
+		local result = getTreeDescendants(root)
+		expect(result).to.be.a("table")
+		expect(#result).to.equal(2)
+	end)
+end


### PR DESCRIPTION
# Problem

The current implementation of the filtering functionality in our Storybook tree view has a limitation. It only checks if the name of the current component node matches the filter text. This means that even if a story matches the filter, if any of its parent folders does not match the filter, the entire subtree gets skipped during rendering.

# Solution

The proposed solution modifies this behavior for non-story nodes (e.g., storybooks, folders). Now, instead of checking if the node's name matches the filter, we check if the node has at least one descendant story that matches the filter. This ensures that folders containing matching stories are not erroneously hidden due to the folder name not matching the filter.

For story nodes, the behavior remains the same as before: the story is displayed if its name matches the filter.

Fix #161 

# Checklist

- [ ] Ran `./bin/test.sh` locally before merging
