### PR TITLE
Run tests in dev mode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-  "luau-lsp.sourcemap.rojoProjectFile": "tests.project.json"
+  "luau-lsp.sourcemap.rojoProjectFile": "tests.project.json",
+  "luau-lsp.types.definitionFiles": [
+    "testez.d.lua"
+  ]
 }

--- a/dev.project.json
+++ b/dev.project.json
@@ -1,6 +1,12 @@
 {
   "name": "flipbook",
   "tree": {
+    "DEV_MODE": {
+      "$className": "BoolValue",
+      "$properties": {
+        "Value": true
+      }
+    },
     "Packages": {
       "$path": "Packages"
     },

--- a/selene.toml
+++ b/selene.toml
@@ -1,4 +1,1 @@
 std = "roblox+testez"
-
-[lints]
-global_usage = "allow"

--- a/src/Common/useDescendants.spec.lua
+++ b/src/Common/useDescendants.spec.lua
@@ -67,6 +67,7 @@ return function()
 
 		ReactRoblox.act(function()
 			folder.Parent = tree
+			task.wait()
 		end)
 
 		expect(#descendants).to.equal(2)
@@ -99,6 +100,7 @@ return function()
 
 		ReactRoblox.act(function()
 			match.Name = "Changed"
+			task.wait()
 		end)
 
 		expect(descendants).never.to.equal(prev)

--- a/src/Common/useEvent.spec.lua
+++ b/src/Common/useEvent.spec.lua
@@ -36,7 +36,10 @@ return function()
 
 		expect(wasFired).to.equal(false)
 
-		bindable:Fire()
+		ReactRoblox.act(function()
+			bindable:Fire()
+			task.wait()
+		end)
 
 		expect(wasFired).to.equal(true)
 	end)
@@ -54,7 +57,10 @@ return function()
 			root:unmount()
 		end)
 
-		bindable:Fire()
+		ReactRoblox.act(function()
+			bindable:Fire()
+			task.wait()
+		end)
 
 		expect(wasFired).to.equal(false)
 	end)

--- a/src/Common/useZoom.spec.lua
+++ b/src/Common/useZoom.spec.lua
@@ -62,6 +62,7 @@ return function()
 
 		ReactRoblox.act(function()
 			zoomIn:Fire()
+			task.wait()
 		end)
 
 		expect(tonumber(result.Text)).to.equal(0.25)
@@ -80,6 +81,7 @@ return function()
 
 		ReactRoblox.act(function()
 			zoomOut:Fire()
+			task.wait()
 		end)
 
 		expect(tonumber(result.Text)).to.equal(-0.25)
@@ -98,6 +100,7 @@ return function()
 
 		ReactRoblox.act(function()
 			zoomIn:Fire()
+			task.wait()
 		end)
 
 		expect(tonumber(result.Text)).to.equal(0.25)

--- a/src/Storybook/findStoryModules.lua
+++ b/src/Storybook/findStoryModules.lua
@@ -1,0 +1,22 @@
+local flipbook = script:FindFirstAncestor("flipbook")
+
+local isStoryModule = require(flipbook.Storybook.isStoryModule)
+
+local function hasPermission(instance: Instance)
+	local success = pcall(function()
+		return instance.Name
+	end)
+	return success
+end
+
+local function findStorybookModules(parent: Instance): { ModuleScript }
+	local modules = {}
+	for _, descendant in parent:GetDescendants() do
+		if hasPermission(descendant) and isStoryModule(descendant) then
+			table.insert(modules, descendant)
+		end
+	end
+	return modules
+end
+
+return findStorybookModules

--- a/src/Storybook/findStoryModules.spec.lua
+++ b/src/Storybook/findStoryModules.spec.lua
@@ -1,0 +1,42 @@
+return function()
+	local flipbook = script:FindFirstAncestor("flipbook")
+
+	local Sift = require(flipbook.Packages.Sift)
+	local newFolder = require(flipbook.Testing.newFolder)
+	local findStoryModules = require(script.Parent.findStoryModules)
+
+	it("should return an array of story modules", function()
+		local storyModule = Instance.new("ModuleScript")
+		local nestedStoryModule = Instance.new("ModuleScript")
+
+		local root = newFolder({
+			["Foo.story"] = storyModule,
+
+			Level1 = newFolder({
+				Level2 = newFolder({
+					Level3 = newFolder({
+						["Bar.story"] = nestedStoryModule,
+					}),
+				}),
+			}),
+
+			NotIncluded = Instance.new("ModuleScript"),
+		})
+
+		local modules = findStoryModules(root)
+
+		expect(modules).to.be.ok()
+		expect(#modules).to.equal(2)
+		expect(Sift.Array.contains(modules, storyModule)).to.equal(true)
+		expect(Sift.Array.contains(modules, nestedStoryModule)).to.equal(true)
+	end)
+
+	it("should return an empty array if no story modules are found", function()
+		local root = Instance.new("Folder")
+
+		local modules = findStoryModules(root)
+
+		expect(modules).to.be.ok()
+		expect(#modules).to.equal(0)
+	end)
+end

--- a/src/Storybook/findStorybookModules.lua
+++ b/src/Storybook/findStorybookModules.lua
@@ -1,0 +1,22 @@
+local flipbook = script:FindFirstAncestor("flipbook")
+
+local isStorybookModule = require(flipbook.Storybook.isStorybookModule)
+
+local function hasPermission(instance: Instance)
+	local success = pcall(function()
+		return instance.Name
+	end)
+	return success
+end
+
+local function findStorybookModules(parent: Instance): { ModuleScript }
+	local modules = {}
+	for _, descendant in parent:GetDescendants() do
+		if hasPermission(descendant) and isStorybookModule(descendant) then
+			table.insert(modules, descendant)
+		end
+	end
+	return modules
+end
+
+return findStorybookModules

--- a/src/Storybook/findStorybookModules.spec.lua
+++ b/src/Storybook/findStorybookModules.spec.lua
@@ -1,0 +1,42 @@
+return function()
+	local flipbook = script:FindFirstAncestor("flipbook")
+
+	local Sift = require(flipbook.Packages.Sift)
+	local newFolder = require(flipbook.Testing.newFolder)
+	local findStorybookModules = require(script.Parent.findStorybookModules)
+
+	it("should return an array of storybook modules", function()
+		local storybookModule = Instance.new("ModuleScript")
+		local nestedStorybookModule = Instance.new("ModuleScript")
+
+		local root = newFolder({
+			["Foo.storybook"] = storybookModule,
+
+			Level1 = newFolder({
+				Level2 = newFolder({
+					Level3 = newFolder({
+						["Bar.storybook"] = nestedStorybookModule,
+					}),
+				}),
+			}),
+
+			NotIncluded = Instance.new("ModuleScript"),
+		})
+
+		local modules = findStorybookModules(root)
+
+		expect(modules).to.be.ok()
+		expect(#modules).to.equal(2)
+		expect(Sift.Array.contains(modules, storybookModule)).to.equal(true)
+		expect(Sift.Array.contains(modules, nestedStorybookModule)).to.equal(true)
+	end)
+
+	it("should return an empty array if no storybook modules are found", function()
+		local root = Instance.new("Folder")
+
+		local modules = findStorybookModules(root)
+
+		expect(modules).to.be.ok()
+		expect(#modules).to.equal(0)
+	end)
+end

--- a/src/Storybook/loadStoriesFromStorybook.lua
+++ b/src/Storybook/loadStoriesFromStorybook.lua
@@ -1,0 +1,30 @@
+local flipbook = script:FindFirstAncestor("flipbook")
+
+local ModuleLoader = require(flipbook.Packages.ModuleLoader)
+local types = require(flipbook.Storybook.types)
+local findStoryModules = require(flipbook.Storybook.findStoryModules)
+local loadStoryModule = require(flipbook.Storybook.loadStoryModule)
+
+type ModuleLoader = typeof(ModuleLoader.new())
+type Story = types.Story
+type Storybook = types.Storybook
+
+local function loadStoriesFromStorybook(storybook: Storybook, loader: ModuleLoader): { Story }
+	local stories = {}
+	local errors = {}
+
+	for _, storyRoot in storybook.storyRoots do
+		for _, storyModule in findStoryModules(storyRoot) do
+			local story, err = loadStoryModule(loader, storyModule, storybook)
+
+			if story then
+				table.insert(stories, story)
+			elseif err then
+				table.insert(errors, err)
+			end
+		end
+	end
+	return stories, errors
+end
+
+return loadStoriesFromStorybook

--- a/src/Storybook/loadStoriesFromStorybook.spec.lua
+++ b/src/Storybook/loadStoriesFromStorybook.spec.lua
@@ -1,0 +1,47 @@
+return function()
+	local flipbook = script:FindFirstAncestor("flipbook")
+
+	local ModuleLoader = require(flipbook.Packages.ModuleLoader)
+	local newFolder = require(flipbook.Testing.newFolder)
+	local types = require(flipbook.Storybook.types)
+	local loadStoriesFromStorybook = require(script.Parent.loadStoriesFromStorybook)
+
+	type Storybook = types.Storybook
+
+	it("should load Story objects from a Storybook", function()
+		local loader = ModuleLoader.new()
+
+		local storyModule = Instance.new("ModuleScript")
+		storyModule.Source = [[
+			return {
+				story = function() end
+			}
+		]]
+
+		local badStoryModule = Instance.new("ModuleScript")
+		badStoryModule.Source = [[
+			return {
+				name = true
+			}
+		]]
+
+		local root = newFolder({
+			Components = newFolder({
+				["Foo.story"] = storyModule,
+
+				Nested = newFolder({
+					["Bar.story"] = badStoryModule,
+				}),
+			}),
+		})
+
+		local storybook: Storybook = {
+			storyRoots = { root },
+		}
+
+		local stories, errors = loadStoriesFromStorybook(storybook, loader)
+
+		expect(#stories).to.equal(1)
+		expect(#errors).to.equal(1)
+	end)
+end

--- a/src/Storybook/loadStorybookModule.lua
+++ b/src/Storybook/loadStorybookModule.lua
@@ -1,0 +1,35 @@
+local flipbook = script:FindFirstAncestor("flipbook")
+
+local ModuleLoader = require(flipbook.Packages.ModuleLoader)
+local types = require(flipbook.Storybook.types)
+local constants = require(flipbook.constants)
+
+type ModuleLoader = typeof(ModuleLoader.new())
+type Storybook = types.Storybook
+
+local function loadStorybook(storybookModule: ModuleScript, loader: ModuleLoader): (Storybook?, string?)
+	local err
+	local success, result = pcall(function()
+		return loader:require(storybookModule)
+	end)
+
+	if success then
+		local isStorybook, message = types.Storybook(result)
+
+		if isStorybook then
+			result.name = if result.name
+				then result.name
+				else storybookModule.Name:gsub(constants.STORYBOOK_NAME_PATTERN, "")
+
+			return result, nil
+		else
+			err = message
+		end
+	else
+		err = result
+	end
+
+	return nil, `Failed to load storybook {storybookModule:GetFullName()}. Error: {err}`
+end
+
+return loadStorybook

--- a/src/Storybook/loadStorybookModule.spec.lua
+++ b/src/Storybook/loadStorybookModule.spec.lua
@@ -1,0 +1,76 @@
+return function()
+	local flipbook = script:FindFirstAncestor("flipbook")
+
+	local ModuleLoader = require(flipbook.Packages.ModuleLoader)
+	local loadStorybookModule = require(script.Parent.loadStorybookModule)
+
+	it("should load a Storybook object from a ModuleScript", function()
+		local loader = ModuleLoader.new()
+
+		local storybookModule = Instance.new("ModuleScript")
+		storybookModule.Name = "Foo.storybook"
+		storybookModule.Source = [[
+			return {
+				storyRoots = {}
+			}
+		]]
+
+		local storybook, err = loadStorybookModule(storybookModule, loader)
+
+		expect(storybook).to.be.ok()
+		expect(err).never.to.be.ok()
+		expect(storybook.storyRoots).to.be.ok()
+		expect(#storybook.storyRoots).to.equal(0)
+	end)
+
+	it("should set the name to the module's name", function()
+		local loader = ModuleLoader.new()
+
+		local storybookModule = Instance.new("ModuleScript")
+		storybookModule.Name = "Foo.storybook"
+		storybookModule.Source = [[
+			return {
+				storyRoots = {}
+			}
+		]]
+
+		local storybook, err = loadStorybookModule(storybookModule, loader)
+
+		expect(storybook).to.be.ok()
+		expect(err).never.to.be.ok()
+		expect(storybook.name).to.equal("Foo")
+	end)
+
+	it("should return an error message for malformed Storybook object", function()
+		local loader = ModuleLoader.new()
+
+		local storybookModule = Instance.new("ModuleScript")
+		storybookModule.Name = "Foo.storybook"
+		storybookModule.Source = [[
+			return {
+				storyRoots = true
+			}
+		]]
+
+		local storybook, err = loadStorybookModule(storybookModule, loader)
+
+		expect(storybook).never.to.be.ok()
+		expect(err).to.be.ok()
+	end)
+
+	it("should return an error message for malformed source", function()
+		local loader = ModuleLoader.new()
+
+		local storybookModule = Instance.new("ModuleScript")
+		storybookModule.Name = "Foo.storybook"
+		storybookModule.Source = [[
+			print(bad)
+			return {}
+		]]
+
+		local storybook, err = loadStorybookModule(storybookModule, loader)
+
+		expect(storybook).never.to.be.ok()
+		expect(err).to.be.ok()
+	end)
+end

--- a/src/Storybook/loadStorybooksFromParent.lua
+++ b/src/Storybook/loadStorybooksFromParent.lua
@@ -1,0 +1,28 @@
+local flipbook = script:FindFirstAncestor("flipbook")
+
+local ModuleLoader = require(flipbook.Packages.ModuleLoader)
+local findStorybookModules = require(flipbook.Storybook.findStorybookModules)
+local loadStorybookModule = require(flipbook.Storybook.loadStorybookModule)
+local types = require(flipbook.Storybook.types)
+
+type Storybook = types.Storybook
+type ModuleLoader = typeof(ModuleLoader.new())
+
+local function loadStorybooks(parent: Instance, loader: ModuleLoader): ({ Storybook }, { string })
+	local storybooks = {}
+	local errors = {}
+
+	for _, storybookModule in findStorybookModules(parent) do
+		local storybook, err = loadStorybookModule(storybookModule, loader)
+
+		if storybook then
+			table.insert(storybooks, storybook)
+		elseif err then
+			table.insert(errors, err)
+		end
+	end
+
+	return storybooks, errors
+end
+
+return loadStorybooks

--- a/src/Storybook/loadStorybooksFromParent.spec.lua
+++ b/src/Storybook/loadStorybooksFromParent.spec.lua
@@ -1,0 +1,53 @@
+return function()
+	local flipbook = script:FindFirstAncestor("flipbook")
+
+	local ModuleLoader = require(flipbook.Packages.ModuleLoader)
+	local newFolder = require(flipbook.Testing.newFolder)
+	local loadStorybooksFromParent = require(script.Parent.loadStorybooksFromParent)
+
+	it("should load Storybook objects from a parent", function()
+		local loader = ModuleLoader.new()
+
+		local storybookModule = Instance.new("ModuleScript")
+		storybookModule.Source = [[
+			return {
+				storyRoots = {}
+			}
+		]]
+
+		local nestedStorybookModule = Instance.new("ModuleScript")
+		nestedStorybookModule.Source = [[
+			return {
+				storyRoots = {}
+			}
+		]]
+
+		local badStorybookModule = Instance.new("ModuleScript")
+		badStorybookModule.Source = [[
+			return {
+				storyRoots = true
+			}
+		]]
+
+		local root = newFolder({
+			["Foo.storybook"] = storybookModule,
+
+			Level1 = newFolder({
+				Level2 = newFolder({
+					Level3 = newFolder({
+						["Bar.storybook"] = nestedStorybookModule,
+					}),
+				}),
+			}),
+
+			["Bad.storybook"] = badStorybookModule,
+
+			NotIncluded = Instance.new("ModuleScript"),
+		})
+
+		local storybooks, errors = loadStorybooksFromParent(root, loader)
+
+		expect(#storybooks).to.equal(2)
+		expect(#errors).to.equal(1)
+	end)
+end

--- a/src/Testing/runTests.lua
+++ b/src/Testing/runTests.lua
@@ -1,0 +1,56 @@
+local ServerScriptService = game:GetService("ServerScriptService")
+
+local flipbook = script:FindFirstAncestor("flipbook") or ServerScriptService:FindFirstChild("flipbook")
+
+local TestEZ = require(flipbook.Packages.TestEZ)
+local withGlobals = require(flipbook.Testing.withGlobals)
+
+local function pruneThirdPartyTests(testRoot: Instance)
+	local tests: { ModuleScript } = {}
+	local thirdPartyInstances = {}
+
+	for _, descendant in ipairs(testRoot:GetDescendants()) do
+		-- Include conditions for any third-party modules here
+		if descendant.Name == "Packages" then
+			table.insert(thirdPartyInstances, descendant)
+		end
+
+		if descendant.Name:match("%.spec$") then
+			table.insert(tests, descendant)
+		end
+	end
+
+	for _, test in tests do
+		for _, thirdPartyInstance in thirdPartyInstances do
+			if test:IsDescendantOf(thirdPartyInstance) then
+				test:Destroy()
+			end
+		end
+	end
+end
+
+local function runTests(testRoot: Instance): string
+	-- Prune any tests that we don't own
+	pruneThirdPartyTests(testRoot)
+
+	local cleanup = withGlobals({
+		__DEV__ = true,
+		__ROACT_17_MOCK_SCHEDULER__ = true,
+	})
+
+	local results = TestEZ.TestBootstrap:run({
+		flipbook,
+	}, TestEZ.Reporters.TextReporterQuiet)
+
+	local success = results.failureCount == 0
+
+	cleanup()
+
+	if success then
+		return "✔️ All tests passed"
+	else
+		return "❌ Test run failed"
+	end
+end
+
+return runTests

--- a/src/Testing/withGlobals.lua
+++ b/src/Testing/withGlobals.lua
@@ -1,0 +1,23 @@
+local function setGlobal(key: string, value: any): any
+	-- selene: allow(global_usage)
+	local prevValue = _G[key]
+	-- selene: allow(global_usage)
+	_G[key] = value
+	return prevValue
+end
+
+local function withGlobals(globals: { [string]: any })
+	local prevValues = {}
+
+	for key, value in globals do
+		prevValues[key] = setGlobal(key, value)
+	end
+
+	return function()
+		for key in globals do
+			setGlobal(key, prevValues[key])
+		end
+	end
+end
+
+return withGlobals

--- a/src/Testing/withGlobals.spec.lua
+++ b/src/Testing/withGlobals.spec.lua
@@ -1,0 +1,37 @@
+return function()
+	local withGlobals = require(script.Parent.withGlobals)
+
+	it("should set a global value until the cleanup function is called", function()
+		expect(_G.FOO).never.to.be.ok()
+
+		local cleanup = withGlobals({
+			FOO = true,
+		})
+
+		expect(_G.FOO).to.be.ok()
+
+		cleanup()
+
+		expect(_G.FOO).never.to.be.ok()
+	end)
+
+	it("should work for any datatype", function()
+		local globals = {
+			GlobalBool = true,
+			GlobalString = "string",
+			GlobalInt = 10,
+		}
+
+		local cleanup = withGlobals(globals)
+
+		for key, value in globals do
+			expect(_G[key]).to.equal(value)
+		end
+
+		cleanup()
+
+		for key, value in globals do
+			expect(_G[key]).never.to.equal(value)
+		end
+	end)
+end

--- a/src/constants.lua
+++ b/src/constants.lua
@@ -10,11 +10,6 @@ return {
 	CONTROLS_MIN_HEIGHT = 100, -- px
 	CONTROLS_MAX_HEIGHT = 400, -- px
 
-	-- Enabling dev mode will add flipbook's storybook to the list of available
-	-- storybooks to make localy testing easier. It also adds a [DEV] tag to the
-	-- plugin
-	IS_DEV_MODE = false,
-
 	SPRING_CONFIG = {
 		clamp = true,
 		mass = 0.6,

--- a/src/init.server.lua
+++ b/src/init.server.lua
@@ -6,18 +6,28 @@ if RunService:IsRunning() or not RunService:IsEdit() then
 	return
 end
 
+local DEV_MODE = flipbook:FindFirstChild("DEV_MODE")
+
+if DEV_MODE then
+	local runTests = require(flipbook.Testing.runTests)
+
+	-- Dev mode must be enabled before React is ever required
+	_G.__DEV__ = true
+
+	runTests(flipbook)
+end
+
 local ModuleLoader = require(flipbook.Packages.ModuleLoader)
 local React = require(flipbook.Packages.React)
 local ReactRoblox = require(flipbook.Packages.ReactRoblox)
 local createWidget = require(flipbook.Plugin.createWidget)
 local createToggleButton = require(flipbook.Plugin.createToggleButton)
 local PluginApp = require(flipbook.Plugin.PluginApp)
-local constants = require(flipbook.constants)
 
 local PLUGIN_NAME = "flipbook"
 
-if constants.IS_DEV_MODE then
-	PLUGIN_NAME = "flipbook [DEV]"
+if DEV_MODE then
+	PLUGIN_NAME ..= " [DEV]"
 end
 
 local toolbar = plugin:CreateToolbar(PLUGIN_NAME)

--- a/src/stories.spec.lua
+++ b/src/stories.spec.lua
@@ -22,8 +22,8 @@ return function()
 			expect(#storyErrors).to.equal(0)
 		end)
 
-		for _, story in stories do
-			it(`should mount/unmount {storybook.name} > {story.name}`, function()
+		for key, story in stories do
+			it(`should mount/unmount {storybook.name} > {story.name} {key}`, function()
 				local controls = {}
 
 				if typeof(story) == "table" and story.controls then

--- a/src/stories.spec.lua
+++ b/src/stories.spec.lua
@@ -2,22 +2,37 @@ local CoreGui = game:GetService("CoreGui")
 
 local flipbook = script:FindFirstAncestor("flipbook")
 
-local React = require(flipbook.Packages.React)
-local ReactRoblox = require(flipbook.Packages.ReactRoblox)
-local isStoryModule = require(flipbook.Storybook.isStoryModule)
+local ModuleLoader = require(flipbook.Packages.ModuleLoader)
+local loadStorybooksFromParent = require(flipbook.Storybook.loadStorybooksFromParent)
+local loadStoriesFromStorybook = require(flipbook.Storybook.loadStoriesFromStorybook)
 local mountStory = require(flipbook.Storybook.mountStory)
 
 return function()
-	for _, descendant in ipairs(flipbook:GetDescendants()) do
-		if isStoryModule(descendant) then
-			it("should mount/unmount " .. descendant.Name, function()
-				local story = require(descendant)
-				story.react = React
-				story.reactRoblox = ReactRoblox
+	local loader = ModuleLoader.new()
+	local storybooks, storybookErrors = loadStorybooksFromParent(flipbook, loader)
+
+	it("should load all storybooks", function()
+		expect(#storybookErrors).to.equal(0)
+	end)
+
+	for _, storybook in storybooks do
+		local stories, storyErrors = loadStoriesFromStorybook(storybook, loader)
+
+		it(`should load all stories for {storybook.name}`, function()
+			expect(#storyErrors).to.equal(0)
+		end)
+
+		for _, story in stories do
+			it(`should mount/unmount {storybook.name} > {story.name}`, function()
+				local controls = {}
+
+				if typeof(story) == "table" and story.controls then
+					controls = story.controls
+				end
 
 				local cleanup
 				expect(function()
-					cleanup = mountStory(story, story.controls, CoreGui)
+					cleanup = mountStory(story, controls, CoreGui)
 				end).to.never.throw()
 
 				if cleanup then


### PR DESCRIPTION
# Problem

Tests can only be run manually via `./bin/test.sh` which is usually good enough, but it would be helpful to have tests run when files are changed

# Solution

Tests are now run in Studio when using the dev project, and when using an accompanying build and watch command this will allow tests to run on file changes

To get this all working I've made some pretty extensive changes:
- Added a new `DEV_MODE` BoolValue to replace `constants.IS_DEV_MODE`. This BoolValue is only set in `dev.project.json`
- Updated tests for `useZoom`, `useDescendants`, `useEvent`, and `stores.spec.lua` to get everything passing in Studio
- `stories.spec.lua` was tricky, and I wound up creating a bunch of helper functions for the discovery and loading of storybooks and stories. With tests!

Also some other minor changes I made are:
- Made Luau LSP aware of our TestEZ type defs so there are no more red squiggles in vscode
- Removed the allow rule for global_usage

# Checklist

- [ ] Ran `./bin/test.sh` locally before merging
