### PR TITLE
Create file watcher to rebuild on changes

### DIFF
--- a/.lune/build.luau
+++ b/.lune/build.luau
@@ -5,30 +5,34 @@ local getPluginsPath = require("./lib/getPluginsPath")
 local parseArgs = require("./lib/parseArgs")
 local process = require("@lune/process")
 local run = require("./lib/run")
+local watch = require("./lib/watcher/watch")
 
 local args = parseArgs(process.args)
 
 local target = if args.target then args.target else "prod"
 local output = if args.output then args.output else `{getPluginsPath(process.os)}/{constants.PLUGIN_FILENAME}`
 
-clean()
-compile(target)
+local function build()
+	clean()
+	compile(target)
 
-if target == "prod" then
-	run("rm", { "-rf", `{constants.BUILD_PATH}/**/*.spec.luau` })
-	run("rm", { "-rf", `{constants.BUILD_PATH}/**/*.story.luau` })
-	run("rm", { "-rf", `{constants.BUILD_PATH}/**/*.storybook.luau` })
+	if target == "prod" then
+		run("rm", { "-rf", `{constants.BUILD_PATH}/**/*.spec.luau` })
+		run("rm", { "-rf", `{constants.BUILD_PATH}/**/*.story.luau` })
+		run("rm", { "-rf", `{constants.BUILD_PATH}/**/*.storybook.luau` })
+	end
+
+	run("rojo", { "build", "-o", output })
 end
 
-run("rojo", { "build", "-o", output })
+build()
 
--- TODO: Watch for file changes and rebuild
--- if args.watch then
--- 	run("npx", {
--- 		"-y",
--- 		"chokidar-cli",
--- 		"src/**/*",
--- 		"-c",
--- 		`lune run build -- --target {target} --output {output}`,
--- 	})
--- end
+if args.watch then
+	watch({
+		filePatterns = {
+			"src/.*%.luau",
+			"example/.*%.luau",
+		},
+		onChanged = build,
+	})
+end

--- a/.lune/lib/watcher/diffArray.luau
+++ b/.lune/lib/watcher/diffArray.luau
@@ -1,0 +1,16 @@
+local function diffArray<T>(base: { T }, compare: { T }): { T }
+	local diff = {}
+	for _, value in compare do
+		if not table.find(base, value) then
+			table.insert(diff, value)
+		end
+	end
+	for _, value in base do
+		if not table.find(compare, value) then
+			table.insert(diff, value)
+		end
+	end
+	return diff
+end
+
+return diffArray

--- a/.lune/lib/watcher/getWatchedFiles.luau
+++ b/.lune/lib/watcher/getWatchedFiles.luau
@@ -1,0 +1,33 @@
+local fs = require("@lune/fs")
+
+local function getWatchedFiles(filePatterns: { string }): { string }
+	local files = {}
+
+	local function traverse(rootDir: string, filePattern: string)
+		for _, file in fs.readDir(rootDir) do
+			local filePath = `{rootDir}/{file}`
+			if fs.isDir(filePath) then
+				traverse(filePath, filePattern)
+			else
+				if filePath:match(filePattern) then
+					table.insert(files, filePath)
+				end
+			end
+		end
+	end
+
+	for _, filePattern in filePatterns do
+		local rootDir = filePattern:split("/")[1]
+
+		assert(
+			rootDir and fs.isDir(rootDir),
+			`first part of file pattern must be a directory ({rootDir} is not a directory)`
+		)
+
+		traverse(rootDir, filePattern)
+	end
+
+	return files
+end
+
+return getWatchedFiles

--- a/.lune/lib/watcher/maybeCall.luau
+++ b/.lune/lib/watcher/maybeCall.luau
@@ -1,4 +1,4 @@
-local function maybeCall(callback: (() -> ())?, ...)
+local function maybeCall<T>(callback: ((...T) -> ())?, ...)
 	if callback then
 		pcall(callback, ...)
 	end

--- a/.lune/lib/watcher/maybeCall.luau
+++ b/.lune/lib/watcher/maybeCall.luau
@@ -1,0 +1,7 @@
+local function maybeCall(callback: (() -> ())?, ...)
+	if callback then
+		pcall(callback, ...)
+	end
+end
+
+return maybeCall

--- a/.lune/lib/watcher/watch.luau
+++ b/.lune/lib/watcher/watch.luau
@@ -1,0 +1,70 @@
+local fs = require("@lune/fs")
+local stdio = require("@lune/stdio")
+local task = require("@lune/task")
+
+local diffArray = require("./diffArray")
+local getWatchedFiles = require("./getWatchedFiles")
+local maybeCall = require("./maybeCall")
+
+type FileChanges = { string }
+
+type Options = {
+	filePatterns: { string },
+	onAdded: ((changedFiles: FileChanges) -> ())?,
+	onRemoved: ((changedFiles: FileChanges) -> ())?,
+	onChanged: ((changedFiles: FileChanges) -> ())?,
+}
+
+local function watch(options: Options)
+	local prevWatchedFileMetadata: { [string]: string } = {}
+	local watchedFiles = getWatchedFiles(options.filePatterns)
+	local prevWatchedFiles
+
+	print("watching files:")
+	stdio.write(stdio.style("dim"))
+	for _, watchedFile in watchedFiles do
+		print(`> {watchedFile}`)
+	end
+	stdio.write(stdio.style("reset"))
+	print("listening for file changes...")
+
+	-- FIXME: Ctrl+C doesn't cancel the loop. Is this a Lune bug or a Foreman bug?
+	while true do
+		local changedFiles: FileChanges = {}
+
+		if prevWatchedFiles and #watchedFiles ~= #prevWatchedFiles then
+			changedFiles = diffArray(prevWatchedFiles, watchedFiles)
+
+			if #watchedFiles > #prevWatchedFiles then
+				maybeCall(options.onAdded, changedFiles)
+			elseif #watchedFiles < #prevWatchedFiles then
+				maybeCall(options.onRemoved, changedFiles)
+
+				for _, filePath in changedFiles do
+					prevWatchedFileMetadata[filePath] = nil
+				end
+			end
+		end
+
+		for _, watchedFile in watchedFiles do
+			local metadata = fs.metadata(watchedFile)
+
+			local prevMetadata = prevWatchedFileMetadata[watchedFile]
+			if prevMetadata and metadata.modifiedAt > prevMetadata.modifiedAt then
+				table.insert(changedFiles, watchedFile)
+			end
+
+			prevWatchedFileMetadata[watchedFile] = metadata
+		end
+
+		if #changedFiles > 0 then
+			maybeCall(options.onChanged, changedFiles)
+		end
+
+		prevWatchedFiles = watchedFiles
+		task.wait(1)
+		watchedFiles = getWatchedFiles(options.filePatterns)
+	end
+end
+
+return watch

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -22,7 +22,8 @@
         "run",
         "build",
         "--",
-        "--target dev"
+        "--target",
+        "dev"
       ],
       "group": {
         "kind": "build",
@@ -38,7 +39,8 @@
         "run",
         "build",
         "--",
-        "--target prod"
+        "--target",
+        "prod"
       ],
       "group": {
         "kind": "build",
@@ -53,7 +55,8 @@
         "run",
         "build",
         "--",
-        "--target dev",
+        "--target",
+        "dev",
         "--watch"
       ]
     },


### PR DESCRIPTION
# Problem

Porting to Lune means we can't use a filewatcher like before with chokidar

# Solution

So I made one. This PR adds a new `watcher` folder to the lune scripts to watch for file changes and rebuild on change

# Checklist

- [x] Ran `lune run test` locally before merging
