### PR TITLE
Add new menu for configuring settings

### DIFF
--- a/src/Common/ContextProviders.luau
+++ b/src/Common/ContextProviders.luau
@@ -1,0 +1,27 @@
+local React = require("@pkg/React")
+
+local ContextStack = require("@root/Common/ContextStack")
+local NavigationContext = require("@root/Navigation/NavigationContext")
+local PluginContext = require("@root/Plugin/PluginContext")
+local SettingsContext = require("@root/UserSettings/SettingsContext")
+
+export type Props = {
+	plugin: Plugin,
+	children: React.Node?,
+}
+
+local function ContextProviders(props: Props)
+	return React.createElement(ContextStack, {
+		providers = {
+			React.createElement(PluginContext.Provider, {
+				plugin = props.plugin,
+			}),
+			React.createElement(NavigationContext.Provider, {
+				defaultScreen = "Home",
+			}),
+			React.createElement(SettingsContext.Provider),
+		},
+	}, props.children)
+end
+
+return ContextProviders

--- a/src/Common/ContextStack.luau
+++ b/src/Common/ContextStack.luau
@@ -1,0 +1,20 @@
+--!strict
+local React = require("@pkg/React")
+
+export type Props = {
+	providers: { React.ReactElement<any, any> },
+	children: React.ReactNode,
+}
+
+local function ContextStack(props: Props)
+	local mostRecent = props.children
+
+	for providerIndex = #props.providers, 1, -1 do
+		local providerElement = props.providers[providerIndex]
+		mostRecent = React.cloneElement(providerElement, nil, mostRecent)
+	end
+
+	return mostRecent
+end
+
+return ContextStack

--- a/src/Common/nextLayoutOrder.luau
+++ b/src/Common/nextLayoutOrder.luau
@@ -1,0 +1,8 @@
+local layoutOrder = 0
+
+local function nextLayoutOrder()
+	layoutOrder += 1
+	return layoutOrder
+end
+
+return nextLayoutOrder

--- a/src/Common/useTheme.luau
+++ b/src/Common/useTheme.luau
@@ -1,5 +1,12 @@
 local React = require("@pkg/React")
+
+local SettingsContext = require("@root/UserSettings/SettingsContext")
 local themes = require("@root/themes")
+local usePrevious = require("@root/Common/usePrevious")
+
+local useMemo = React.useMemo
+local useState = React.useState
+local useEffect = React.useEffect
 
 local MOCK_STUDIO = {
 	ThemeChanged = Instance.new("BindableEvent").Event,
@@ -9,7 +16,12 @@ local MOCK_STUDIO = {
 }
 
 local function useTheme()
-	local studio = React.useMemo(function()
+	local settingsContext = SettingsContext.use()
+
+	local themeOverride = settingsContext.getSetting("theme")
+	local prevThemeOverride = usePrevious(themeOverride)
+
+	local studio: Studio = useMemo(function()
 		local success, result = pcall(function()
 			return (settings() :: any).Studio
 		end)
@@ -17,17 +29,38 @@ local function useTheme()
 		return if success then result else MOCK_STUDIO
 	end, {})
 
-	local theme: themes.Theme, set = React.useState(themes[studio.Theme.Name])
-
-	React.useEffect(function()
-		local conn = studio.ThemeChanged:Connect(function()
-			set(themes[studio.Theme.Name])
-		end)
-
-		return function()
-			conn:Disconnect()
+	local themeName = useMemo(function()
+		if themeOverride ~= "system" then
+			if themeOverride == "dark" then
+				return "Dark"
+			elseif themeOverride == "light" then
+				return "Light"
+			end
 		end
-	end, {})
+		return studio.Theme.Name
+	end, { themeOverride, studio })
+
+	local theme: themes.Theme, set = useState(themes[themeName])
+
+	useEffect(function()
+		if themeOverride ~= prevThemeOverride then
+			set(themes[themeName])
+		end
+	end, { themeOverride, prevThemeOverride, themeName })
+
+	useEffect(function()
+		if themeOverride == "system" then
+			local conn = studio.ThemeChanged:Connect(function()
+				set(themes[studio.Theme.Name])
+			end)
+
+			return function()
+				conn:Disconnect()
+			end
+		else
+			return nil
+		end
+	end, { themeOverride })
 
 	return theme
 end

--- a/src/Forms/Checkbox.luau
+++ b/src/Forms/Checkbox.luau
@@ -22,7 +22,7 @@ local function Checkbox(props: Props)
 
 	return React.createElement("ImageButton", {
 		BackgroundColor3 = theme.button,
-		Size = UDim2.fromOffset(theme.textSize, theme.textSize) + UDim2.new(theme.padding, theme.padding),
+		Size = UDim2.fromOffset(theme.buttonTextSize, theme.buttonTextSize) + UDim2.new(theme.padding, theme.padding),
 		[React.Event.Activated] = toggle,
 	}, {
 		Layout = React.createElement("UIListLayout", {
@@ -31,19 +31,19 @@ local function Checkbox(props: Props)
 		}),
 
 		Corner = React.createElement("UICorner", {
-			CornerRadius = theme.paddingSmall,
+			CornerRadius = theme.corner,
 		}),
 
 		Border = React.createElement("UIStroke", {
 			Color = theme.buttonText,
-			Transparency = 0.4,
-			Thickness = 2,
+			Transparency = 0.6,
+			Thickness = 1,
 		}),
 
 		Check = isChecked and React.createElement("TextLabel", {
 			Text = "✔️",
-			TextSize = theme.textSize,
-			Font = theme.headerFont,
+			TextSize = theme.buttonTextSize,
+			Font = theme.buttonFont,
 			TextColor3 = theme.buttonText,
 			BackgroundTransparency = 1,
 			AutomaticSize = Enum.AutomaticSize.XY,

--- a/src/Forms/Dropdown.luau
+++ b/src/Forms/Dropdown.luau
@@ -18,8 +18,8 @@ local function Dropdown(props: Props)
 		options["Option" .. index] = React.createElement("TextButton", {
 			LayoutOrder = index,
 			Text = tostring(option),
-			Font = theme.font,
-			TextSize = theme.textSize,
+			Font = theme.buttonFont,
+			TextSize = theme.buttonTextSize,
 			TextColor3 = theme.buttonText,
 			AutomaticSize = Enum.AutomaticSize.XY,
 			BackgroundColor3 = theme.buttonText,
@@ -34,20 +34,20 @@ local function Dropdown(props: Props)
 			end,
 		}, {
 			Padding = React.createElement("UIPadding", {
-				PaddingTop = theme.padding,
+				PaddingTop = theme.paddingSmall,
 				PaddingRight = theme.padding,
-				PaddingBottom = theme.padding,
+				PaddingBottom = theme.paddingSmall,
 				PaddingLeft = theme.padding,
 			}),
 		})
 	end
 
-	local maxHeight = theme.textSize + (theme.padding.Offset * 2)
+	local maxHeight = theme.buttonTextSize + (theme.paddingSmall.Offset * 2)
 
 	return React.createElement("TextButton", {
 		Text = tostring(if selectedOption then selectedOption else props.placeholder),
-		Font = theme.font,
-		TextSize = theme.textSize,
+		Font = theme.buttonFont,
+		TextSize = theme.buttonTextSize,
 		TextColor3 = theme.buttonText,
 		BackgroundColor3 = theme.button,
 		Size = UDim2.fromOffset(0, maxHeight),
@@ -57,20 +57,20 @@ local function Dropdown(props: Props)
 		end,
 	}, {
 		Corner = React.createElement("UICorner", {
-			CornerRadius = theme.paddingSmall,
+			CornerRadius = theme.corner,
 		}),
 
 		Border = React.createElement("UIStroke", {
 			ApplyStrokeMode = Enum.ApplyStrokeMode.Border,
 			Color = theme.buttonText,
-			Transparency = 0.4,
-			Thickness = 2,
+			Transparency = 0.6,
+			Thickness = 1,
 		}),
 
 		Padding = React.createElement("UIPadding", {
-			PaddingTop = theme.padding,
+			PaddingTop = theme.paddingSmall,
 			PaddingRight = theme.padding,
-			PaddingBottom = theme.padding,
+			PaddingBottom = theme.paddingSmall,
 			PaddingLeft = theme.padding,
 		}),
 
@@ -85,13 +85,14 @@ local function Dropdown(props: Props)
 			}),
 
 			Corner = React.createElement("UICorner", {
-				CornerRadius = theme.paddingSmall,
+				CornerRadius = theme.corner,
 			}),
 
 			Border = React.createElement("UIStroke", {
+				ApplyStrokeMode = Enum.ApplyStrokeMode.Border,
 				Color = theme.buttonText,
-				Transparency = 0.4,
-				Thickness = 2,
+				Transparency = 0.6,
+				Thickness = 1,
 			}),
 
 			Options = React.createElement(React.Fragment, nil, options),

--- a/src/Navigation/Item.luau
+++ b/src/Navigation/Item.luau
@@ -6,7 +6,7 @@ local useTheme = require("@root/Common/useTheme")
 local e = React.createElement
 
 type Props = {
-	active: boolean,
+	active: boolean?,
 	layoutOrder: number,
 	onClick: () -> (),
 	padding: { x: number, y: number }?,

--- a/src/Navigation/Items.luau
+++ b/src/Navigation/Items.luau
@@ -4,7 +4,7 @@ local e = React.createElement
 
 type Props = {
 	layoutOrder: number,
-	padding: UDim,
+	padding: UDim?,
 	children: any,
 }
 

--- a/src/Navigation/NavigationContext.luau
+++ b/src/Navigation/NavigationContext.luau
@@ -5,6 +5,7 @@ local navigationEnums = require("@root/Navigation/enums")
 
 local useCallback = React.useCallback
 local useContext = React.useContext
+local useMemo = React.useMemo
 local useState = React.useState
 
 type Screen = navigationEnums.Screen
@@ -32,37 +33,33 @@ local function Provider(props: Props)
 		end)
 	end, {})
 
-	local getCurrentScreen = useCallback(function()
+	local currentScreen = useMemo(function()
 		return stack[#stack]
 	end, { stack })
 
-	local canGoBack = useCallback(function()
+	local canGoBack = useMemo(function()
 		return #stack > 1
 	end, { stack })
 
 	local goBack = useCallback(function()
-		if canGoBack() then
+		if canGoBack then
 			setStack(function(prev)
 				return Sift.Array.pop(prev)
 			end)
 		end
 	end, { canGoBack })
 
-	local getBreadcrumbs = useCallback(function()
-		return stack
-	end, { stack })
-
 	return React.createElement(Context.Provider, {
 		value = {
 			navigateTo = navigateTo,
 			goBack = goBack,
-			getBreadcrumbs = getBreadcrumbs,
-			getCurrentScreen = getCurrentScreen,
+			breadcrumbs = stack,
+			currentScreen = currentScreen,
 		},
 	}, props.children)
 end
 
-local function use()
+local function use(): NavigationContext
 	return useContext(Context)
 end
 

--- a/src/Navigation/NavigationContext.luau
+++ b/src/Navigation/NavigationContext.luau
@@ -1,0 +1,73 @@
+local React = require("@pkg/React")
+local Sift = require("@pkg/Sift")
+
+local navigationEnums = require("@root/Navigation/enums")
+
+local useCallback = React.useCallback
+local useContext = React.useContext
+local useState = React.useState
+
+type Screen = navigationEnums.Screen
+
+export type NavigationContext = {
+	navigateTo: (newScreen: Screen) -> (),
+	goBack: () -> (),
+	getBreadcrumbs: () -> { string },
+	canGoBack: () -> boolean,
+}
+
+local Context = React.createContext({})
+
+export type Props = {
+	defaultScreen: Screen,
+	children: React.Node?,
+}
+
+local function Provider(props: Props)
+	local stack: { Screen }, setStack = useState({ props.defaultScreen })
+
+	local navigateTo = useCallback(function(newScreen: string)
+		setStack(function(prev)
+			return Sift.Array.push(prev, newScreen)
+		end)
+	end, {})
+
+	local getCurrentScreen = useCallback(function()
+		return stack[#stack]
+	end, { stack })
+
+	local canGoBack = useCallback(function()
+		return #stack > 1
+	end, { stack })
+
+	local goBack = useCallback(function()
+		if canGoBack() then
+			setStack(function(prev)
+				return Sift.Array.pop(prev)
+			end)
+		end
+	end, { canGoBack })
+
+	local getBreadcrumbs = useCallback(function()
+		return stack
+	end, { stack })
+
+	return React.createElement(Context.Provider, {
+		value = {
+			navigateTo = navigateTo,
+			goBack = goBack,
+			getBreadcrumbs = getBreadcrumbs,
+			getCurrentScreen = getCurrentScreen,
+		},
+	}, props.children)
+end
+
+local function use()
+	return useContext(Context)
+end
+
+return {
+	Context = Context,
+	Provider = Provider,
+	use = use,
+}

--- a/src/Navigation/Screen.luau
+++ b/src/Navigation/Screen.luau
@@ -1,0 +1,38 @@
+local React = require("@pkg/React")
+
+local NavigationContext = require("@root/Navigation/NavigationContext")
+local SettingsView = require("@root/UserSettings/SettingsView")
+local StoryCanvas = require("@root/Storybook/StoryCanvas")
+local storybookTypes = require("@root/Storybook/types")
+
+local useMemo = React.useMemo
+
+type Story = storybookTypes.Story
+type Storybook = storybookTypes.Storybook
+
+export type Props = {
+	loader: any,
+	story: Story?,
+	storybook: Storybook?,
+}
+
+local function Screen(props: Props)
+	local navigation = NavigationContext.use()
+	local currentScreen = navigation.currentScreen
+
+	local screenElement = useMemo(function()
+		if currentScreen == "Home" then
+			return React.createElement(StoryCanvas, {
+				loader = props.loader,
+				story = props.story,
+				storybook = props.storybook,
+			})
+		elseif currentScreen == "Settings" then
+			return React.createElement(SettingsView)
+		end
+	end, { props, currentScreen })
+
+	return screenElement
+end
+
+return Screen

--- a/src/Navigation/enums.luau
+++ b/src/Navigation/enums.luau
@@ -1,0 +1,9 @@
+local enums = {}
+
+export type Screen = "Home" | "Settings"
+enums.Screen = {
+	Home = "Home" :: Screen,
+	Settings = "Settings" :: Screen,
+}
+
+return enums

--- a/src/Panels/Topbar.luau
+++ b/src/Panels/Topbar.luau
@@ -1,0 +1,83 @@
+local React = require("@pkg/React")
+
+local Navigation = require("@root/Navigation")
+local NavigationContext = require("@root/Navigation/NavigationContext")
+local Sprite = require("@root/Common/Sprite")
+local assets = require("@root/assets")
+local nextLayoutOrder = require("@root/Common/nextLayoutOrder")
+local useTheme = require("@root/Common/useTheme")
+
+local useCallback = React.useCallback
+
+export type Props = {
+	LayoutOrder: number?,
+}
+
+local function NavbarRoot(props: Props)
+	local theme = useTheme()
+	local navigation = NavigationContext.use()
+
+	local navigateToSettings = useCallback(function()
+		navigation.navigateTo("Settings")
+	end, { navigation.navigateTo })
+
+	return React.createElement(Navigation.Items, {
+		layoutOrder = props.LayoutOrder,
+	}, {
+		Padding = React.createElement("UIPadding", {
+			PaddingTop = theme.paddingSmall,
+			PaddingRight = theme.paddingSmall,
+			PaddingBottom = theme.paddingSmall,
+			PaddingLeft = theme.paddingSmall,
+		}),
+
+		Settings = React.createElement(Navigation.Item, {
+			layoutOrder = nextLayoutOrder(),
+			onClick = navigateToSettings,
+		}, {
+			Text = React.createElement("TextLabel", {
+				AutomaticSize = Enum.AutomaticSize.XY,
+				BackgroundTransparency = 1,
+				Font = theme.font,
+				Size = UDim2.fromScale(0, 0),
+				Text = "Settings",
+				TextColor3 = theme.textFaded,
+				TextSize = theme.textSize,
+				TextXAlignment = Enum.TextXAlignment.Left,
+				TextYAlignment = Enum.TextYAlignment.Top,
+			}),
+		}),
+	})
+end
+
+return NavbarRoot
+
+-- local function Topbar(props: Props)
+-- 	local theme = useTheme()
+-- 	local navigation = NavigationContext.use()
+
+-- 	return React.createElement("Frame", {
+-- 		Size = UDim2.fromScale(1, 1),
+-- 		BackgroundColor3 = theme.sidebar,
+-- 		BorderSizePixel = 0,
+-- 	}, {
+-- 		LayoutOrder = React.createElement("UIListLayout", {
+-- 			SortOrder = Enum.SortOrder.LayoutOrder,
+-- 			HorizontalAlignment = Enum.HorizontalAlignment.Right,
+-- 		}),
+
+-- 		Navbar = React.createElement("Frame", {}, {
+-- 			LayoutOrder = React.createElement("UIListLayout", {
+-- 				SortOrder = Enum.SortOrder.LayoutOrder,
+-- 				HorizontalAlignment = Enum.HorizontalAlignment.Right,
+-- 			}),
+
+-- 			Settings = React.createElement(Button, {
+-- 				layoutOrder = nextLayoutOrder(),
+-- 				text = "Settings",
+-- 			}),
+-- 		}),
+-- 	})
+-- end
+
+-- return Topbar

--- a/src/Panels/Topbar.luau
+++ b/src/Panels/Topbar.luau
@@ -2,55 +2,68 @@ local React = require("@pkg/React")
 
 local Navigation = require("@root/Navigation")
 local NavigationContext = require("@root/Navigation/NavigationContext")
-local Sprite = require("@root/Common/Sprite")
-local assets = require("@root/assets")
 local nextLayoutOrder = require("@root/Common/nextLayoutOrder")
 local useTheme = require("@root/Common/useTheme")
 
 local useCallback = React.useCallback
 
 export type Props = {
+	Size: UDim2?,
 	LayoutOrder: number?,
 }
 
-local function NavbarRoot(props: Props)
+local function Topbar(props: Props)
 	local theme = useTheme()
 	local navigation = NavigationContext.use()
 
 	local navigateToSettings = useCallback(function()
-		navigation.navigateTo("Settings")
-	end, { navigation.navigateTo })
+		if navigation.currentScreen == "Settings" then
+			navigation.goBack()
+		else
+			navigation.navigateTo("Settings")
+		end
+	end, { navigation.navigateTo, navigation.currentScreen })
 
-	return React.createElement(Navigation.Items, {
-		layoutOrder = props.LayoutOrder,
+	return React.createElement("Frame", {
+		BackgroundColor3 = theme.sidebar,
+		LayoutOrder = props.LayoutOrder,
+		Size = props.Size,
 	}, {
-		Padding = React.createElement("UIPadding", {
-			PaddingTop = theme.paddingSmall,
-			PaddingRight = theme.paddingSmall,
-			PaddingBottom = theme.paddingSmall,
-			PaddingLeft = theme.paddingSmall,
+		Layout = React.createElement("UIListLayout", {
+			HorizontalAlignment = Enum.HorizontalAlignment.Right,
 		}),
 
-		Settings = React.createElement(Navigation.Item, {
-			layoutOrder = nextLayoutOrder(),
-			onClick = navigateToSettings,
+		NavItems = React.createElement(Navigation.Items, {
+			layoutOrder = props.LayoutOrder,
 		}, {
-			Text = React.createElement("TextLabel", {
-				AutomaticSize = Enum.AutomaticSize.XY,
-				BackgroundTransparency = 1,
-				Font = theme.font,
-				Size = UDim2.fromScale(0, 0),
-				Text = "Settings",
-				TextColor3 = theme.textFaded,
-				TextSize = theme.textSize,
-				TextXAlignment = Enum.TextXAlignment.Left,
-				TextYAlignment = Enum.TextYAlignment.Top,
+			Padding = React.createElement("UIPadding", {
+				PaddingTop = theme.paddingSmall,
+				PaddingRight = theme.paddingSmall,
+				PaddingBottom = theme.paddingSmall,
+				PaddingLeft = theme.paddingSmall,
+			}),
+
+			Settings = React.createElement(Navigation.Item, {
+				layoutOrder = nextLayoutOrder(),
+				onClick = navigateToSettings,
+			}, {
+				Text = React.createElement("TextLabel", {
+					AutomaticSize = Enum.AutomaticSize.XY,
+					BackgroundTransparency = 1,
+					Font = theme.font,
+					Size = UDim2.fromScale(0, 0),
+					Text = "Settings",
+					TextColor3 = theme.textFaded,
+					TextSize = theme.textSize,
+					TextXAlignment = Enum.TextXAlignment.Left,
+					TextYAlignment = Enum.TextYAlignment.Top,
+				}),
 			}),
 		}),
 	})
 end
 
-return NavbarRoot
+return Topbar
 
 -- local function Topbar(props: Props)
 -- 	local theme = useTheme()

--- a/src/Plugin/PluginApp.luau
+++ b/src/Plugin/PluginApp.luau
@@ -1,6 +1,8 @@
+local ContextStack = require("@root/Common/ContextStack")
 local PluginContext = require("@root/Plugin/PluginContext")
 local React = require("@pkg/React")
 local ResizablePanel = require("@root/Panels/ResizablePanel")
+local SettingsContext = require("@root/UserSettings/SettingsContext")
 local Sidebar = require("@root/Panels/Sidebar")
 local StoryCanvas = require("@root/Storybook/StoryCanvas")
 local constants = require("@root/constants")
@@ -29,8 +31,13 @@ local function App(props: Props)
 		setSidebarWidth(newSize.X)
 	end, {})
 
-	return React.createElement(PluginContext.Provider, {
-		plugin = props.plugin,
+	return React.createElement(ContextStack, {
+		providers = {
+			React.createElement(PluginContext.Provider, {
+				plugin = props.plugin,
+			}),
+			React.createElement(SettingsContext.Provider),
+		},
 	}, {
 		Background = React.createElement("Frame", {
 			BackgroundColor3 = theme.background,

--- a/src/Plugin/PluginApp.luau
+++ b/src/Plugin/PluginApp.luau
@@ -1,13 +1,18 @@
 local ContextStack = require("@root/Common/ContextStack")
+local NavigationContext = require("@root/Navigation/NavigationContext")
 local PluginContext = require("@root/Plugin/PluginContext")
 local React = require("@pkg/React")
 local ResizablePanel = require("@root/Panels/ResizablePanel")
 local SettingsContext = require("@root/UserSettings/SettingsContext")
 local Sidebar = require("@root/Panels/Sidebar")
 local StoryCanvas = require("@root/Storybook/StoryCanvas")
+local Topbar = require("@root/Panels/Topbar")
 local constants = require("@root/constants")
+local nextLayoutOrder = require("@root/Common/nextLayoutOrder")
 local useStorybooks = require("@root/Storybook/useStorybooks")
 local useTheme = require("@root/Common/useTheme")
+
+local TOPBAR_HEIGHT_PX = 32
 
 export type Props = {
 	plugin: Plugin,
@@ -36,6 +41,9 @@ local function App(props: Props)
 			React.createElement(PluginContext.Provider, {
 				plugin = props.plugin,
 			}),
+			React.createElement(NavigationContext.Provider, {
+				defaultScreen = "Home",
+			}),
 			React.createElement(SettingsContext.Provider),
 		},
 	}, {
@@ -50,7 +58,7 @@ local function App(props: Props)
 			}),
 
 			SidebarWrapper = React.createElement(ResizablePanel, {
-				layoutOrder = 1,
+				layoutOrder = nextLayoutOrder(),
 				initialSize = UDim2.new(0, constants.SIDEBAR_INITIAL_WIDTH, 1, 0),
 				dragHandles = { "Right" },
 				minSize = Vector2.new(constants.SIDEBAR_MIN_WIDTH, 0),
@@ -65,13 +73,33 @@ local function App(props: Props)
 			}),
 
 			MainWrapper = React.createElement("Frame", {
-				LayoutOrder = 2,
+				LayoutOrder = nextLayoutOrder(),
 				Size = UDim2.fromScale(1, 1) - UDim2.fromOffset(sidebarWidth, 0),
 			}, {
-				StoryCanvas = React.createElement(StoryCanvas, {
-					loader = props.loader,
-					story = story,
-					storybook = storybook,
+				Layout = React.createElement("UIListLayout", {
+					SortOrder = Enum.SortOrder.LayoutOrder,
+				}),
+
+				TopbarWrapper = React.createElement("Frame", {
+					LayoutOrder = nextLayoutOrder(),
+					Size = UDim2.new(1, 0, 0, TOPBAR_HEIGHT_PX),
+					BackgroundTransparency = 1,
+				}, {
+					Topbar = React.createElement(Topbar, {
+						LayoutOrder = nextLayoutOrder(),
+					}),
+				}),
+
+				StoryCanvasWrapper = React.createElement("Frame", {
+					LayoutOrder = nextLayoutOrder(),
+					Size = UDim2.fromScale(1, 1) - UDim2.fromOffset(0, TOPBAR_HEIGHT_PX),
+					BackgroundTransparency = 1,
+				}, {
+					StoryCanvas = React.createElement(StoryCanvas, {
+						loader = props.loader,
+						story = story,
+						storybook = storybook,
+					}),
 				}),
 			}),
 		}),

--- a/src/Plugin/PluginApp.luau
+++ b/src/Plugin/PluginApp.luau
@@ -1,11 +1,8 @@
-local ContextStack = require("@root/Common/ContextStack")
 local NavigationContext = require("@root/Navigation/NavigationContext")
-local PluginContext = require("@root/Plugin/PluginContext")
 local React = require("@pkg/React")
 local ResizablePanel = require("@root/Panels/ResizablePanel")
-local SettingsContext = require("@root/UserSettings/SettingsContext")
+local Screen = require("@root/Navigation/Screen")
 local Sidebar = require("@root/Panels/Sidebar")
-local StoryCanvas = require("@root/Storybook/StoryCanvas")
 local Topbar = require("@root/Panels/Topbar")
 local constants = require("@root/constants")
 local nextLayoutOrder = require("@root/Common/nextLayoutOrder")
@@ -15,7 +12,6 @@ local useTheme = require("@root/Common/useTheme")
 local TOPBAR_HEIGHT_PX = 32
 
 export type Props = {
-	plugin: Plugin,
 	loader: any,
 }
 
@@ -25,81 +21,67 @@ local function App(props: Props)
 	local story, setStory = React.useState(nil)
 	local storybook, selectStorybook = React.useState(nil)
 	local sidebarWidth, setSidebarWidth = React.useState(constants.SIDEBAR_INITIAL_WIDTH)
+	local navigation = NavigationContext.use()
 
 	local selectStory = React.useCallback(function(newStory: ModuleScript)
+		navigation.navigateTo("Home")
+
 		setStory(function(prevStory: ModuleScript)
 			return if prevStory ~= newStory then newStory else nil
 		end)
-	end, { setStory })
+	end, { setStory, navigation.navigateTo })
 
 	local onSidebarResized = React.useCallback(function(newSize: Vector2)
 		setSidebarWidth(newSize.X)
 	end, {})
 
-	return React.createElement(ContextStack, {
-		providers = {
-			React.createElement(PluginContext.Provider, {
-				plugin = props.plugin,
-			}),
-			React.createElement(NavigationContext.Provider, {
-				defaultScreen = "Home",
-			}),
-			React.createElement(SettingsContext.Provider),
-		},
+	return React.createElement("Frame", {
+		BackgroundColor3 = theme.background,
+		Size = UDim2.fromScale(1, 1),
 	}, {
-		Background = React.createElement("Frame", {
-			BackgroundColor3 = theme.background,
-			Size = UDim2.fromScale(1, 1),
+		Layout = React.createElement("UIListLayout", {
+			FillDirection = Enum.FillDirection.Horizontal,
+			SortOrder = Enum.SortOrder.LayoutOrder,
+			VerticalAlignment = Enum.VerticalAlignment.Center,
+		}),
+
+		SidebarWrapper = React.createElement(ResizablePanel, {
+			layoutOrder = nextLayoutOrder(),
+			initialSize = UDim2.new(0, constants.SIDEBAR_INITIAL_WIDTH, 1, 0),
+			dragHandles = { "Right" },
+			minSize = Vector2.new(constants.SIDEBAR_MIN_WIDTH, 0),
+			maxSize = Vector2.new(constants.SIDEBAR_MAX_WIDTH, math.huge),
+			onResize = onSidebarResized,
+		}, {
+			Sidebar = React.createElement(Sidebar, {
+				selectStory = selectStory,
+				selectStorybook = selectStorybook,
+				storybooks = storybooks,
+			}),
+		}),
+
+		MainWrapper = React.createElement("Frame", {
+			LayoutOrder = nextLayoutOrder(),
+			Size = UDim2.fromScale(1, 1) - UDim2.fromOffset(sidebarWidth, 0),
 		}, {
 			Layout = React.createElement("UIListLayout", {
-				FillDirection = Enum.FillDirection.Horizontal,
 				SortOrder = Enum.SortOrder.LayoutOrder,
-				VerticalAlignment = Enum.VerticalAlignment.Center,
 			}),
 
-			SidebarWrapper = React.createElement(ResizablePanel, {
-				layoutOrder = nextLayoutOrder(),
-				initialSize = UDim2.new(0, constants.SIDEBAR_INITIAL_WIDTH, 1, 0),
-				dragHandles = { "Right" },
-				minSize = Vector2.new(constants.SIDEBAR_MIN_WIDTH, 0),
-				maxSize = Vector2.new(constants.SIDEBAR_MAX_WIDTH, math.huge),
-				onResize = onSidebarResized,
-			}, {
-				Sidebar = React.createElement(Sidebar, {
-					selectStory = selectStory,
-					selectStorybook = selectStorybook,
-					storybooks = storybooks,
-				}),
-			}),
-
-			MainWrapper = React.createElement("Frame", {
+			Topbar = React.createElement(Topbar, {
+				Size = UDim2.new(1, 0, 0, TOPBAR_HEIGHT_PX),
 				LayoutOrder = nextLayoutOrder(),
-				Size = UDim2.fromScale(1, 1) - UDim2.fromOffset(sidebarWidth, 0),
+			}),
+
+			ScreenWrapper = React.createElement("Frame", {
+				LayoutOrder = nextLayoutOrder(),
+				Size = UDim2.fromScale(1, 1) - UDim2.fromOffset(0, TOPBAR_HEIGHT_PX),
+				BackgroundTransparency = 1,
 			}, {
-				Layout = React.createElement("UIListLayout", {
-					SortOrder = Enum.SortOrder.LayoutOrder,
-				}),
-
-				TopbarWrapper = React.createElement("Frame", {
-					LayoutOrder = nextLayoutOrder(),
-					Size = UDim2.new(1, 0, 0, TOPBAR_HEIGHT_PX),
-					BackgroundTransparency = 1,
-				}, {
-					Topbar = React.createElement(Topbar, {
-						LayoutOrder = nextLayoutOrder(),
-					}),
-				}),
-
-				StoryCanvasWrapper = React.createElement("Frame", {
-					LayoutOrder = nextLayoutOrder(),
-					Size = UDim2.fromScale(1, 1) - UDim2.fromOffset(0, TOPBAR_HEIGHT_PX),
-					BackgroundTransparency = 1,
-				}, {
-					StoryCanvas = React.createElement(StoryCanvas, {
-						loader = props.loader,
-						story = story,
-						storybook = storybook,
-					}),
+				Screen = React.createElement(Screen, {
+					loader = props.loader,
+					story = story,
+					storybook = storybook,
 				}),
 			}),
 		}),

--- a/src/Testing/MockPlugin.luau
+++ b/src/Testing/MockPlugin.luau
@@ -1,0 +1,20 @@
+local MockPlugin = {}
+MockPlugin.__index = MockPlugin
+
+function MockPlugin.new()
+	local self = {
+		_settings = {},
+	}
+
+	return setmetatable(self, MockPlugin)
+end
+
+function MockPlugin:GetSetting(settingName: string)
+	return self._settings[settingName]
+end
+
+function MockPlugin:SetSetting(settingName: string, newValue: any)
+	self._settings[settingName] = newValue
+end
+
+return MockPlugin

--- a/src/Testing/renderHook.luau
+++ b/src/Testing/renderHook.luau
@@ -1,0 +1,37 @@
+local React = require("@pkg/React")
+local ReactRoblox = require("@pkg/ReactRoblox")
+
+local act = ReactRoblox.act
+
+type Options = {
+	wrapper: React.ComponentType<{
+		children: React.ReactNode,
+	}>,
+}
+
+local function renderHook<T...>(hook: () -> T..., options: Options?): () -> T...
+	local result = React.createRef()
+
+	local function TestComponent()
+		result.current = table.pack(hook())
+	end
+
+	local container = Instance.new("Folder")
+	local root = ReactRoblox.createRoot(container)
+
+	local element = React.createElement(TestComponent)
+
+	if options and options.wrapper then
+		element = React.createElement(options.wrapper, nil, element)
+	end
+
+	act(function()
+		root:render(element)
+	end)
+
+	return function()
+		return table.unpack(result.current)
+	end
+end
+
+return renderHook

--- a/src/Testing/renderHook.spec.luau
+++ b/src/Testing/renderHook.spec.luau
@@ -1,0 +1,51 @@
+local JestGlobals = require("@pkg/JestGlobals")
+local React = require("@pkg/React")
+local ReactRoblox = require("@pkg/ReactRoblox")
+local renderHook = require("./renderHook")
+
+local test = JestGlobals.test
+local expect = JestGlobals.expect
+
+local act = ReactRoblox.act
+
+test("works with useState", function()
+	local getHookResult = renderHook(function()
+		return React.useState(1)
+	end)
+
+	local state, setState = getHookResult()
+
+	expect(state).toBe(1)
+
+	act(function()
+		setState(2)
+	end)
+
+	state, setState = getHookResult()
+
+	expect(state).toBe(2)
+end)
+
+test("can supply a wrapper element", function()
+	local context = React.createContext({})
+
+	local function Provider(props): React.Node
+		return React.createElement(context.Provider, {
+			value = {
+				isWrapped = true,
+			},
+		}, props.children)
+	end
+
+	local getHookResult = renderHook(function()
+		return React.useContext(context)
+	end, {
+		wrapper = Provider,
+	})
+
+	local result = getHookResult()
+
+	expect(result).toEqual({
+		isWrapped = true,
+	})
+end)

--- a/src/UserSettings/SettingRow.luau
+++ b/src/UserSettings/SettingRow.luau
@@ -1,0 +1,134 @@
+local React = require("@pkg/React")
+local Sift = require("@pkg/Sift")
+
+local Checkbox = require("@root/Forms/Checkbox")
+local Dropdown = require("@root/Forms/Dropdown")
+local SettingsContext = require("@root/UserSettings/SettingsContext")
+local defaultSettings = require("@root/UserSettings/defaultSettings")
+local nextLayoutOrder = require("@root/Common/nextLayoutOrder")
+local useTheme = require("@root/Common/useTheme")
+
+local useCallback = React.useCallback
+local useMemo = React.useMemo
+
+local CHANGE_INDICATOR_WIDTH_PX = 2
+
+type Setting = defaultSettings.Setting
+type SettingChoice = defaultSettings.SettingChoice
+
+export type Props = {
+	setting: Setting,
+	layoutOrder: number?,
+}
+
+local function SettingRow(props: Props)
+	local settingsContext = SettingsContext.use()
+	local theme = useTheme()
+
+	local setSetting = useCallback(function(newValue: any)
+		settingsContext.setSetting(props.setting.name, newValue)
+	end, { settingsContext.setSetting, props.setting })
+
+	local optionElement = useMemo(function()
+		if props.setting.settingType == "checkbox" then
+			return React.createElement(Checkbox, {
+				initialState = props.setting.value,
+				onStateChange = setSetting,
+			})
+		elseif props.setting.settingType == "dropdown" then
+			return React.createElement(Dropdown, {
+				default = props.setting.choices[1].name,
+				options = Sift.List.map(props.setting.choices, function(choice: SettingChoice)
+					return choice.name
+				end),
+				onOptionChange = setSetting,
+			})
+		end
+		error(`no handling for setting type {props.setting.settingType}`)
+	end, { props.setting, setSetting })
+
+	local hasBeenChanged = not settingsContext.isSettingDefault(props.setting.name)
+
+	return React.createElement("Frame", {
+		BorderSizePixel = 0,
+		BackgroundColor3 = if props.layoutOrder and props.layoutOrder % 2 == 0 then theme.sidebar else theme.background,
+		LayoutOrder = props.layoutOrder,
+		Size = UDim2.fromScale(1, 0),
+		AutomaticSize = Enum.AutomaticSize.Y,
+	}, {
+		ChangedIndicator = if hasBeenChanged
+			then React.createElement("Frame", {
+				Size = UDim2.new(0, CHANGE_INDICATOR_WIDTH_PX, 1, 0),
+				BorderSizePixel = 0,
+				BackgroundColor3 = theme.selection,
+			})
+			else nil,
+
+		Main = React.createElement("Frame", {
+			Size = UDim2.fromScale(1, 0),
+			BackgroundTransparency = 1,
+			AutomaticSize = Enum.AutomaticSize.Y,
+		}, {
+			Layout = React.createElement("UIListLayout", {
+				SortOrder = Enum.SortOrder.LayoutOrder,
+				Padding = theme.padding,
+			}),
+
+			Padding = React.createElement("UIPadding", {
+				PaddingTop = theme.paddingSmall,
+				PaddingRight = theme.padding,
+				PaddingBottom = theme.paddingSmall,
+				PaddingLeft = theme.padding,
+			}),
+
+			Info = React.createElement("Frame", {
+				LayoutOrder = nextLayoutOrder(),
+				BackgroundTransparency = 1,
+				Size = UDim2.fromScale(1, 0),
+				AutomaticSize = Enum.AutomaticSize.Y,
+			}, {
+				Layout = React.createElement("UIListLayout", {
+					SortOrder = Enum.SortOrder.LayoutOrder,
+					Padding = theme.paddingSmall,
+				}),
+
+				Name = React.createElement("TextLabel", {
+					LayoutOrder = nextLayoutOrder(),
+					Text = props.setting.displayName,
+					Size = UDim2.fromScale(1, 0),
+					AutomaticSize = Enum.AutomaticSize.Y,
+					BackgroundTransparency = 1,
+					Font = theme.font,
+					TextColor3 = theme.text,
+					TextSize = theme.textSize,
+					TextXAlignment = Enum.TextXAlignment.Left,
+					TextYAlignment = Enum.TextYAlignment.Top,
+				}),
+
+				Description = React.createElement("TextLabel", {
+					LayoutOrder = nextLayoutOrder(),
+					Text = props.setting.description,
+					Size = UDim2.fromScale(1, 0),
+					AutomaticSize = Enum.AutomaticSize.Y,
+					BackgroundTransparency = 1,
+					Font = theme.font,
+					TextColor3 = theme.textSubtitle,
+					TextSize = theme.textSize,
+					TextXAlignment = Enum.TextXAlignment.Left,
+					TextYAlignment = Enum.TextYAlignment.Top,
+				}),
+			}),
+
+			OptionWrapper = React.createElement("Frame", {
+				LayoutOrder = nextLayoutOrder(),
+				BackgroundTransparency = 1,
+				Size = UDim2.fromScale(1 / 2, 0),
+				AutomaticSize = Enum.AutomaticSize.Y,
+			}, {
+				Option = optionElement,
+			}),
+		}),
+	})
+end
+
+return SettingRow

--- a/src/UserSettings/SettingRow.luau
+++ b/src/UserSettings/SettingRow.luau
@@ -51,7 +51,7 @@ local function SettingRow(props: Props)
 
 	return React.createElement("Frame", {
 		BorderSizePixel = 0,
-		BackgroundColor3 = if props.layoutOrder and props.layoutOrder % 2 == 0 then theme.sidebar else theme.background,
+		BackgroundColor3 = if props.layoutOrder and props.layoutOrder % 2 == 0 then theme.background else theme.sidebar,
 		LayoutOrder = props.layoutOrder,
 		Size = UDim2.fromScale(1, 0),
 		AutomaticSize = Enum.AutomaticSize.Y,
@@ -75,10 +75,10 @@ local function SettingRow(props: Props)
 			}),
 
 			Padding = React.createElement("UIPadding", {
-				PaddingTop = theme.paddingSmall,
-				PaddingRight = theme.padding,
-				PaddingBottom = theme.paddingSmall,
-				PaddingLeft = theme.padding,
+				PaddingTop = theme.padding,
+				PaddingRight = theme.paddingLarge,
+				PaddingBottom = theme.padding,
+				PaddingLeft = theme.paddingLarge,
 			}),
 
 			Info = React.createElement("Frame", {

--- a/src/UserSettings/SettingsContext.luau
+++ b/src/UserSettings/SettingsContext.luau
@@ -64,7 +64,11 @@ local function Provider(props: Props)
 	local setSetting = useCallback(function(settingName: string, newValue: any)
 		plugin:SetSetting(settingName, newValue)
 		setSettings(loadSettingsFromDisk)
-	end, { plugin })
+	end, { plugin, loadSettingsFromDisk })
+
+	local getSetting = useCallback(function(settingName: string)
+		return settings[settingName].value
+	end, { settings })
 
 	return React.createElement(Context.Provider, {
 		value = {
@@ -72,6 +76,7 @@ local function Provider(props: Props)
 			getSettingDefault = getSettingDefault,
 			isSettingDefault = isSettingDefault,
 			setSetting = setSetting,
+			getSetting = getSetting,
 		},
 	}, props.children)
 end

--- a/src/UserSettings/SettingsContext.luau
+++ b/src/UserSettings/SettingsContext.luau
@@ -19,6 +19,9 @@ export type Props = {
 
 export type SettingsContext = {
 	settings: Settings,
+
+	getSettingDefault: (settingName: string) -> any,
+	isSettingDefault: (settingName: string) -> boolean,
 	setSetting: (settingName: string, newValue: any) -> (),
 }
 
@@ -41,20 +44,36 @@ local function Provider(props: Props)
 		return loadSettingsFromDisk()
 	end)
 
+	local getSettingDefault = useCallback(function(settingName: string)
+		local setting = defaultSettings[settingName]
+		if setting.settingType == "dropdown" then
+			return setting.choices[1].name
+		elseif setting.settingType == "checkbox" then
+			return setting.value
+		else
+			return nil
+		end
+	end, {})
+
+	local isSettingDefault = useCallback(function(settingName: string)
+		local defaultValue = getSettingDefault(settingName)
+		local savedValue = plugin:GetSetting(settingName)
+
+		return savedValue == nil or savedValue == defaultValue
+	end, { plugin, getSettingDefault })
+
 	local setSetting = useCallback(function(settingName: string, newValue: any)
 		plugin:SetSetting(settingName, newValue)
 		setSettings(loadSettingsFromDisk)
 	end, { plugin })
 
-	local context: SettingsContext = useMemo(function()
-		return {
-			settings = settings,
-			setSetting = setSetting,
-		}
-	end, { settings })
-
 	return React.createElement(Context.Provider, {
-		value = context,
+		value = {
+			settings = settings,
+			getSettingDefault = getSettingDefault,
+			isSettingDefault = isSettingDefault,
+			setSetting = setSetting,
+		},
 	}, props.children)
 end
 

--- a/src/UserSettings/SettingsContext.luau
+++ b/src/UserSettings/SettingsContext.luau
@@ -6,7 +6,6 @@ local defaultSettings = require("./defaultSettings")
 
 local useCallback = React.useCallback
 local useContext = React.useContext
-local useMemo = React.useMemo
 local useState = React.useState
 
 type Settings = defaultSettings.Settings

--- a/src/UserSettings/SettingsContext.luau
+++ b/src/UserSettings/SettingsContext.luau
@@ -1,0 +1,69 @@
+local React = require("@pkg/React")
+local Sift = require("@pkg/Sift")
+
+local PluginContext = require("@root/Plugin/PluginContext")
+local defaultSettings = require("./defaultSettings")
+
+local useCallback = React.useCallback
+local useContext = React.useContext
+local useMemo = React.useMemo
+local useState = React.useState
+
+type Settings = defaultSettings.Settings
+
+local Context = React.createContext({})
+
+export type Props = {
+	children: React.Node?,
+}
+
+export type SettingsContext = {
+	settings: Settings,
+	setSetting: (settingName: string, newValue: any) -> (),
+}
+
+local function Provider(props: Props)
+	local plugin = useContext(PluginContext.Context)
+
+	local loadSettingsFromDisk = useCallback(function()
+		local settings = {}
+		for settingName, setting in defaultSettings do
+			local savedValue = plugin:GetSetting(settingName)
+
+			settings[settingName] = Sift.Dictionary.join(setting, {
+				value = savedValue,
+			})
+		end
+		return settings :: Settings
+	end, { plugin })
+
+	local settings, setSettings = useState(function()
+		return loadSettingsFromDisk()
+	end)
+
+	local setSetting = useCallback(function(settingName: string, newValue: any)
+		plugin:SetSetting(settingName, newValue)
+		setSettings(loadSettingsFromDisk)
+	end, { plugin })
+
+	local context: SettingsContext = useMemo(function()
+		return {
+			settings = settings,
+			setSetting = setSetting,
+		}
+	end, { settings })
+
+	return React.createElement(Context.Provider, {
+		value = context,
+	}, props.children)
+end
+
+local function use(): SettingsContext
+	return React.useContext(Context)
+end
+
+return {
+	Context = Context,
+	Provider = Provider,
+	use = use,
+}

--- a/src/UserSettings/SettingsContext.spec.luau
+++ b/src/UserSettings/SettingsContext.spec.luau
@@ -2,9 +2,8 @@ local JestGlobals = require("@pkg/JestGlobals")
 local React = require("@pkg/React")
 local ReactRoblox = require("@pkg/ReactRoblox")
 
-local ContextStack = require("@root/Common/ContextStack")
+local ContextProviders = require("@root/Common/ContextProviders")
 local MockPlugin = require("@root/Testing/MockPlugin")
-local PluginContext = require("@root/Plugin/PluginContext")
 local SettingsContext = require("./SettingsContext")
 local defaultSettings = require("./defaultSettings")
 local renderHook = require("@root/Testing/renderHook")
@@ -24,13 +23,8 @@ beforeEach(function()
 	mockPlugin = MockPlugin.new()
 
 	function ContextWrapper(props)
-		return React.createElement(ContextStack, {
-			providers = {
-				React.createElement(PluginContext.Provider, {
-					plugin = mockPlugin :: any,
-				}),
-				React.createElement(SettingsContext.Provider),
-			},
+		return React.createElement(ContextProviders, {
+			plugin = mockPlugin :: any,
 		}, props.children)
 	end
 

--- a/src/UserSettings/SettingsContext.spec.luau
+++ b/src/UserSettings/SettingsContext.spec.luau
@@ -1,0 +1,86 @@
+local JestGlobals = require("@pkg/JestGlobals")
+local React = require("@pkg/React")
+local ReactRoblox = require("@pkg/ReactRoblox")
+
+local ContextStack = require("@root/Common/ContextStack")
+local MockPlugin = require("@root/Testing/MockPlugin")
+local PluginContext = require("@root/Plugin/PluginContext")
+local SettingsContext = require("./SettingsContext")
+local defaultSettings = require("./defaultSettings")
+local renderHook = require("@root/Testing/renderHook")
+
+local beforeEach = JestGlobals.beforeEach
+local describe = JestGlobals.describe
+local expect = JestGlobals.expect
+local jest = JestGlobals.jest
+local test = JestGlobals.test
+
+local act = ReactRoblox.act
+
+local mockPlugin
+local ContextWrapper
+
+beforeEach(function()
+	mockPlugin = MockPlugin.new()
+
+	function ContextWrapper(props)
+		return React.createElement(ContextStack, {
+			providers = {
+				React.createElement(PluginContext.Provider, {
+					plugin = mockPlugin :: any,
+				}),
+				React.createElement(SettingsContext.Provider),
+			},
+		}, props.children)
+	end
+
+	jest.clearAllMocks()
+end)
+
+describe("hook", function()
+	test("return default settings when no changes have been made", function()
+		local get = renderHook(function()
+			return SettingsContext.use()
+		end, {
+			wrapper = ContextWrapper,
+		})
+
+		local settingsContext = get()
+
+		expect(settingsContext.settings).toEqual(defaultSettings)
+	end)
+
+	test("local plugin settings override defaults", function()
+		mockPlugin:SetSetting("rememberLastOpenedStory", false)
+
+		local get = renderHook(function()
+			return SettingsContext.use()
+		end, {
+			wrapper = ContextWrapper,
+		})
+
+		local settingsContext = get()
+
+		expect(settingsContext.settings.rememberLastOpenedStory.value).toBe(false)
+	end)
+
+	test.only("set setting value via context", function()
+		local get = renderHook(function()
+			return SettingsContext.use()
+		end, {
+			wrapper = ContextWrapper,
+		})
+
+		local settingsContext = get()
+
+		expect(settingsContext.settings.rememberLastOpenedStory.value).toBe(true)
+
+		act(function()
+			settingsContext.setSetting("rememberLastOpenedStory", false)
+		end)
+
+		settingsContext = get()
+
+		expect(settingsContext.settings.rememberLastOpenedStory.value).toBe(false)
+	end)
+end)

--- a/src/UserSettings/SettingsView.luau
+++ b/src/UserSettings/SettingsView.luau
@@ -1,9 +1,11 @@
 local React = require("@pkg/React")
 local Sift = require("@pkg/Sift")
 
+local ScrollingFrame = require("@root/Common/ScrollingFrame")
 local SettingRow = require("@root/UserSettings/SettingRow")
 local SettingsContext = require("@root/UserSettings/SettingsContext")
 local defaultSettings = require("@root/UserSettings/defaultSettings")
+local nextLayoutOrder = require("@root/Common/nextLayoutOrder")
 local useTheme = require("@root/Common/useTheme")
 
 local useMemo = React.useMemo
@@ -30,16 +32,44 @@ local function SettingsView()
 		})
 	end
 
-	return React.createElement("Frame", {
-		BackgroundTransparency = 1,
-		Size = UDim2.fromScale(1, 0),
-		AutomaticSize = Enum.AutomaticSize.Y,
+	return React.createElement(ScrollingFrame, {
+		BackgroundColor3 = theme.background,
+		BackgroundTransparency = 0,
 	}, {
 		Layout = React.createElement("UIListLayout", {
 			SortOrder = Enum.SortOrder.LayoutOrder,
-			Padding = theme.padding,
 		}),
-	}, children)
+
+		Title = React.createElement("TextLabel", {
+			LayoutOrder = nextLayoutOrder(),
+			AutomaticSize = Enum.AutomaticSize.XY,
+			BackgroundTransparency = 1,
+			Font = theme.headerFont,
+			Size = UDim2.fromScale(0, 0),
+			Text = "Settings",
+			TextColor3 = theme.text,
+			TextSize = theme.headerTextSize,
+		}, {
+			Padding = React.createElement("UIPadding", {
+				PaddingTop = theme.paddingLarge,
+				PaddingRight = theme.paddingLarge,
+				PaddingBottom = theme.paddingLarge,
+				PaddingLeft = theme.paddingLarge,
+			}),
+		}),
+
+		Settings = React.createElement("Frame", {
+			LayoutOrder = nextLayoutOrder(),
+			Size = UDim2.fromScale(1, 0),
+			AutomaticSize = Enum.AutomaticSize.Y,
+			BackgroundTransparency = 1,
+		}, {
+			Layout = React.createElement("UIListLayout", {
+				SortOrder = Enum.SortOrder.LayoutOrder,
+				Padding = theme.padding,
+			}),
+		}, children),
+	})
 end
 
 return SettingsView

--- a/src/UserSettings/SettingsView.luau
+++ b/src/UserSettings/SettingsView.luau
@@ -1,0 +1,37 @@
+local React = require("@pkg/React")
+
+local SettingRow = require("@root/UserSettings/SettingRow")
+local SettingsContext = require("@root/UserSettings/SettingsContext")
+local defaultSettings = require("@root/UserSettings/defaultSettings")
+local useTheme = require("@root/Common/useTheme")
+
+type Setting = defaultSettings.Setting
+type SettingChoice = defaultSettings.SettingChoice
+
+local function SettingsView()
+	local settingsContext = SettingsContext.use()
+	local theme = useTheme()
+
+	local children = {}
+	local index = 0
+	for _, setting: Setting in settingsContext.settings do
+		index += 1
+		children[setting.name] = React.createElement(SettingRow, {
+			setting = setting,
+			layoutOrder = index,
+		})
+	end
+
+	return React.createElement("Frame", {
+		BackgroundTransparency = 1,
+		Size = UDim2.fromScale(1, 0),
+		AutomaticSize = Enum.AutomaticSize.Y,
+	}, {
+		Layout = React.createElement("UIListLayout", {
+			SortOrder = Enum.SortOrder.LayoutOrder,
+			Padding = theme.padding,
+		}),
+	}, children)
+end
+
+return SettingsView

--- a/src/UserSettings/SettingsView.luau
+++ b/src/UserSettings/SettingsView.luau
@@ -1,9 +1,12 @@
 local React = require("@pkg/React")
+local Sift = require("@pkg/Sift")
 
 local SettingRow = require("@root/UserSettings/SettingRow")
 local SettingsContext = require("@root/UserSettings/SettingsContext")
 local defaultSettings = require("@root/UserSettings/defaultSettings")
 local useTheme = require("@root/Common/useTheme")
+
+local useMemo = React.useMemo
 
 type Setting = defaultSettings.Setting
 type SettingChoice = defaultSettings.SettingChoice
@@ -12,10 +15,15 @@ local function SettingsView()
 	local settingsContext = SettingsContext.use()
 	local theme = useTheme()
 
+	local orderedSettings: { Setting } = useMemo(function()
+		local values = Sift.Dictionary.values(settingsContext.settings)
+		return Sift.Array.sort(values, function(a: Setting, b: Setting)
+			return a.name < b.name
+		end)
+	end, { settingsContext.settings })
+
 	local children = {}
-	local index = 0
-	for _, setting: Setting in settingsContext.settings do
-		index += 1
+	for index, setting in orderedSettings do
 		children[setting.name] = React.createElement(SettingRow, {
 			setting = setting,
 			layoutOrder = index,

--- a/src/UserSettings/SettingsView.story.luau
+++ b/src/UserSettings/SettingsView.story.luau
@@ -1,20 +1,13 @@
 local React = require("@pkg/React")
 
-local ContextStack = require("@root/Common/ContextStack")
+local ContextProviders = require("@root/Common/ContextProviders")
 local MockPlugin = require("@root/Testing/MockPlugin")
-local PluginContext = require("@root/Plugin/PluginContext")
-local SettingsContext = require("./SettingsContext")
 local SettingsView = require("./SettingsView")
 
 return {
 	story = function()
-		return React.createElement(ContextStack, {
-			providers = {
-				React.createElement(PluginContext.Provider, {
-					plugin = MockPlugin.new(),
-				}),
-				React.createElement(SettingsContext.Provider),
-			},
+		return React.createElement(ContextProviders, {
+			plugin = MockPlugin.new(),
 		}, {
 			SettingsView = React.createElement(SettingsView),
 		})

--- a/src/UserSettings/SettingsView.story.luau
+++ b/src/UserSettings/SettingsView.story.luau
@@ -1,0 +1,22 @@
+local React = require("@pkg/React")
+
+local ContextStack = require("@root/Common/ContextStack")
+local MockPlugin = require("@root/Testing/MockPlugin")
+local PluginContext = require("@root/Plugin/PluginContext")
+local SettingsContext = require("./SettingsContext")
+local SettingsView = require("./SettingsView")
+
+return {
+	story = function()
+		return React.createElement(ContextStack, {
+			providers = {
+				React.createElement(PluginContext.Provider, {
+					plugin = MockPlugin.new(),
+				}),
+				React.createElement(SettingsContext.Provider),
+			},
+		}, {
+			SettingsView = React.createElement(SettingsView),
+		})
+	end,
+}

--- a/src/UserSettings/defaultSettings.luau
+++ b/src/UserSettings/defaultSettings.luau
@@ -1,21 +1,55 @@
-export type Setting<T> = {
+export type SettingType = "checkbox" | "dropdown"
+
+export type SettingChoice = {
+	name: string,
+	description: string,
+}
+
+type BaseSetting = {
 	name: string,
 	displayName: string,
 	description: string,
-	value: T,
+	settingType: SettingType,
 }
 
-local expandNodesOnStart: Setting<"Always" | "Never" | "LastOpened"> = {
+type CheckboxSetting = BaseSetting & {
+	settingType: "checkbox",
+	value: boolean,
+}
+
+type DropdownSetting = BaseSetting & {
+	settingType: "dropdown",
+	choices: { SettingChoice },
+}
+
+export type Setting = CheckboxSetting | DropdownSetting
+
+local expandNodesOnStart: Setting = {
 	name = "expandNodesOnStart",
 	displayName = "Expand nodes on start",
 	description = "Re-open the storybooks and folders from before",
-	value = "RememberLast",
+	settingType = "dropdown",
+	choices = {
+		{
+			name = "off",
+			description = "Keep all explorer nodes closed on startup",
+		},
+		{
+			name = "all",
+			description = "All explorer nodes are opened on startup",
+		},
+		{
+			name = "lastOpened",
+			description = "Reopen the nodes that were opened from previous sessions on startup",
+		},
+	},
 }
 
-local rememberLastOpenedStory: Setting<boolean> = {
+local rememberLastOpenedStory: Setting = {
 	name = "rememberLastOpenedStory",
 	displayName = "Remember last opened story",
 	description = "Open the last viewed story when starting",
+	settingType = "checkbox",
 	value = true,
 }
 

--- a/src/UserSettings/defaultSettings.luau
+++ b/src/UserSettings/defaultSettings.luau
@@ -1,0 +1,29 @@
+export type Setting<T> = {
+	name: string,
+	displayName: string,
+	description: string,
+	value: T,
+}
+
+local expandNodesOnStart: Setting<"Always" | "Never" | "LastOpened"> = {
+	name = "expandNodesOnStart",
+	displayName = "Expand nodes on start",
+	description = "Re-open the storybooks and folders from before",
+	value = "RememberLast",
+}
+
+local rememberLastOpenedStory: Setting<boolean> = {
+	name = "rememberLastOpenedStory",
+	displayName = "Remember last opened story",
+	description = "Open the last viewed story when starting",
+	value = true,
+}
+
+local settings = {
+	expandNodesOnStart = expandNodesOnStart,
+	rememberLastOpenedStory = rememberLastOpenedStory,
+}
+
+export type Settings = typeof(settings)
+
+return settings

--- a/src/UserSettings/defaultSettings.luau
+++ b/src/UserSettings/defaultSettings.luau
@@ -53,9 +53,31 @@ local rememberLastOpenedStory: Setting = {
 	value = true,
 }
 
+local theme: Setting = {
+	name = "theme",
+	displayName = "UI theme",
+	description = "Select the UI theme to use. By default, flipbook will use the same theme as Studio",
+	settingType = "dropdown",
+	choices = {
+		{
+			name = "system",
+			description = "Match the theme selected for Studio",
+		},
+		{
+			name = "dark",
+			description = "Force the theme to use dark mode",
+		},
+		{
+			name = "light",
+			description = "Force the theme to use light mode",
+		},
+	},
+}
+
 local settings = {
 	expandNodesOnStart = expandNodesOnStart,
 	rememberLastOpenedStory = rememberLastOpenedStory,
+	theme = theme,
 }
 
 export type Settings = typeof(settings)

--- a/src/UserSettings/defaultSettings.luau
+++ b/src/UserSettings/defaultSettings.luau
@@ -24,34 +24,34 @@ type DropdownSetting = BaseSetting & {
 
 export type Setting = CheckboxSetting | DropdownSetting
 
-local expandNodesOnStart: Setting = {
-	name = "expandNodesOnStart",
-	displayName = "Expand nodes on start",
-	description = "Re-open the storybooks and folders from before",
-	settingType = "dropdown",
-	choices = {
-		{
-			name = "off",
-			description = "Keep all explorer nodes closed on startup",
-		},
-		{
-			name = "all",
-			description = "All explorer nodes are opened on startup",
-		},
-		{
-			name = "lastOpened",
-			description = "Reopen the nodes that were opened from previous sessions on startup",
-		},
-	},
-}
+-- local expandNodesOnStart: Setting = {
+-- 	name = "expandNodesOnStart",
+-- 	displayName = "Expand nodes on start",
+-- 	description = "Re-open the storybooks and folders from before",
+-- 	settingType = "dropdown",
+-- 	choices = {
+-- 		{
+-- 			name = "off",
+-- 			description = "Keep all explorer nodes closed on startup",
+-- 		},
+-- 		{
+-- 			name = "all",
+-- 			description = "All explorer nodes are opened on startup",
+-- 		},
+-- 		{
+-- 			name = "lastOpened",
+-- 			description = "Reopen the nodes that were opened from previous sessions on startup",
+-- 		},
+-- 	},
+-- }
 
-local rememberLastOpenedStory: Setting = {
-	name = "rememberLastOpenedStory",
-	displayName = "Remember last opened story",
-	description = "Open the last viewed story when starting",
-	settingType = "checkbox",
-	value = true,
-}
+-- local rememberLastOpenedStory: Setting = {
+-- 	name = "rememberLastOpenedStory",
+-- 	displayName = "Remember last opened story",
+-- 	description = "Open the last viewed story when starting",
+-- 	settingType = "checkbox",
+-- 	value = true,
+-- }
 
 local theme: Setting = {
 	name = "theme",

--- a/src/UserSettings/defaultSettings.luau
+++ b/src/UserSettings/defaultSettings.luau
@@ -75,8 +75,8 @@ local theme: Setting = {
 }
 
 local settings = {
-	expandNodesOnStart = expandNodesOnStart,
-	rememberLastOpenedStory = rememberLastOpenedStory,
+	-- expandNodesOnStart = expandNodesOnStart,
+	-- rememberLastOpenedStory = rememberLastOpenedStory,
 	theme = theme,
 }
 

--- a/src/init.server.luau
+++ b/src/init.server.luau
@@ -5,9 +5,11 @@ if RunService:IsRunning() or not RunService:IsEdit() then
 end
 
 local ModuleLoader = require("@pkg/ModuleLoader")
-local PluginApp = require("@root/Plugin/PluginApp")
 local React = require("@pkg/React")
 local ReactRoblox = require("@pkg/ReactRoblox")
+
+local ContextProviders = require("@root/Common/ContextProviders")
+local PluginApp = require("@root/Plugin/PluginApp")
 local constants = require("@root/constants")
 local createToggleButton = require("@root/Plugin/createToggleButton")
 local createWidget = require("@root/Plugin/createWidget")
@@ -25,9 +27,12 @@ local disconnectButton = createToggleButton(toolbar, widget)
 
 local loader = ModuleLoader.new()
 
-local app = React.createElement(PluginApp, {
+local app = React.createElement(ContextProviders, {
 	plugin = plugin,
-	loader = loader,
+}, {
+	PluginApp = React.createElement(PluginApp, {
+		loader = loader,
+	}),
 })
 
 local widgetConn = widget:GetPropertyChangedSignal("Enabled"):Connect(function()

--- a/src/themes.luau
+++ b/src/themes.luau
@@ -5,6 +5,8 @@ export type Theme = {
 	font: Enum.Font,
 	headerTextSize: number,
 	headerFont: Enum.Font,
+	buttonTextSize: number,
+	buttonFont: Enum.Font,
 
 	background: Color3,
 	sidebar: Color3,
@@ -28,10 +30,12 @@ export type Theme = {
 
 return {
 	Light = {
-		textSize = 14,
-		font = Enum.Font.GothamMedium,
-		headerTextSize = 24,
-		headerFont = Enum.Font.GothamBlack,
+		textSize = 18,
+		font = Enum.Font.BuilderSansMedium,
+		headerTextSize = 32,
+		headerFont = Enum.Font.BuilderSansExtraBold,
+		buttonTextSize = 14,
+		buttonFont = Enum.Font.BuilderSansBold,
 
 		background = tailwind.white,
 		sidebar = tailwind.gray100,
@@ -42,6 +46,7 @@ return {
 		divider = tailwind.gray300,
 		text = tailwind.gray800,
 		textFaded = tailwind.gray600,
+		textSubtitle = tailwind.gray500,
 		selection = tailwind.purple500,
 		story = tailwind.green500,
 		directory = tailwind.purple500,
@@ -51,24 +56,27 @@ return {
 		paddingSmall = UDim.new(0, 6),
 		paddingLarge = UDim.new(0, 24),
 
-		corner = UDim.new(0, 6),
+		corner = UDim.new(0, 4),
 	} :: Theme,
 
 	Dark = {
-		textSize = 14,
-		font = Enum.Font.GothamMedium,
-		headerTextSize = 24,
-		headerFont = Enum.Font.GothamBlack,
+		textSize = 18,
+		font = Enum.Font.BuilderSansMedium,
+		headerTextSize = 32,
+		headerFont = Enum.Font.BuilderSansExtraBold,
+		buttonTextSize = 14,
+		buttonFont = Enum.Font.BuilderSansBold,
 
 		background = tailwind.zinc800,
 		sidebar = tailwind.zinc900,
 		canvas = tailwind.zinc800,
 		scrollbar = tailwind.zinc100,
 		button = tailwind.zinc300,
-		buttonText = tailwind.zinc900,
+		buttonText = tailwind.zinc800,
 		divider = tailwind.zinc700,
 		text = tailwind.zinc200,
 		textFaded = tailwind.zinc300,
+		textSubtitle = tailwind.zinc400,
 		selection = tailwind.purple500,
 		story = tailwind.green500,
 		directory = tailwind.purple500,


### PR DESCRIPTION
# Problem

flipbook has no way for users to configure settings, so this makes it hard for us to introduce changes that might not be for everyone.

# Solution

A new settings menu has been added! Along with all the work needed to handle navigation between views.

Clicking "Settings" along the top right opens the view.

<img width="895" alt="Screenshot 2024-05-06 at 12 16 01 PM" src="https://github.com/flipbook-labs/flipbook/assets/3081936/472f9047-8764-47dd-a225-ac87a6ba20c2">

Right now "UI Theme" is the only setting that does anything. This PR was getting a bit unwieldy, and I think to support expand/collapse/focus behavior in the tree view will require some heavy lifting.

# Checklist

- [ ] Ran `lune run test` locally before merging
