### PR TITLE
Delete .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.luau linguist-language=Lua


### PR DESCRIPTION
# Problem

Lua syntax highlighting instead of Luau on Github.

# Solution

Deleted .gitattributes

# Checklist

- [ ] Ran `lune run test` locally before merging
