### PR TITLE
Add settings for panel sizes

### DIFF
--- a/src/Forms/InputField.luau
+++ b/src/Forms/InputField.luau
@@ -12,7 +12,7 @@ local defaultProps = {
 
 export type Props = {
 	layoutOrder: number?,
-	onSubmit: (text: string) -> (),
+	onSubmit: (text: string, isValid: boolean) -> (),
 	onFocus: (() -> ())?,
 	onFocusLost: (() -> ())?,
 	onTextChange: ((new: string, old: string) -> ())?,
@@ -35,8 +35,8 @@ local function InputField(providedProps: Props)
 			props.onFocusLost()
 		end
 
-		if enterPressed and isValid and props.onSubmit then
-			props.onSubmit(text)
+		if enterPressed and props.onSubmit then
+			props.onSubmit(text, isValid)
 		end
 	end, {
 		isValid,

--- a/src/Plugin/PluginApp.luau
+++ b/src/Plugin/PluginApp.luau
@@ -1,7 +1,9 @@
-local NavigationContext = require("@root/Navigation/NavigationContext")
 local React = require("@pkg/React")
+
+local NavigationContext = require("@root/Navigation/NavigationContext")
 local ResizablePanel = require("@root/Panels/ResizablePanel")
 local Screen = require("@root/Navigation/Screen")
+local SettingsContext = require("@root/UserSettings/SettingsContext")
 local Sidebar = require("@root/Panels/Sidebar")
 local Topbar = require("@root/Panels/Topbar")
 local constants = require("@root/constants")
@@ -17,10 +19,12 @@ export type Props = {
 
 local function App(props: Props)
 	local theme = useTheme()
+	local settingsContext = SettingsContext.use()
 	local storybooks = useStorybooks(game, props.loader)
 	local story, setStory = React.useState(nil)
 	local storybook, selectStorybook = React.useState(nil)
-	local sidebarWidth, setSidebarWidth = React.useState(constants.SIDEBAR_INITIAL_WIDTH)
+	local initialSidebarWidth = settingsContext.getSetting("sidebarWidth")
+	local sidebarWidth, setSidebarWidth = React.useState(initialSidebarWidth)
 	local navigation = NavigationContext.use()
 
 	local selectStory = React.useCallback(function(newStory: ModuleScript)
@@ -47,7 +51,7 @@ local function App(props: Props)
 
 		SidebarWrapper = React.createElement(ResizablePanel, {
 			layoutOrder = nextLayoutOrder(),
-			initialSize = UDim2.new(0, constants.SIDEBAR_INITIAL_WIDTH, 1, 0),
+			initialSize = UDim2.new(0, initialSidebarWidth, 1, 0),
 			dragHandles = { "Right" },
 			minSize = Vector2.new(constants.SIDEBAR_MIN_WIDTH, 0),
 			maxSize = Vector2.new(constants.SIDEBAR_MAX_WIDTH, math.huge),

--- a/src/Storybook/StoryView.luau
+++ b/src/Storybook/StoryView.luau
@@ -4,6 +4,7 @@ local PluginContext = require("@root/Plugin/PluginContext")
 local React = require("@pkg/React")
 local ResizablePanel = require("@root/Panels/ResizablePanel")
 local ScrollingFrame = require("@root/Common/ScrollingFrame")
+local SettingsContext = require("@root/UserSettings/SettingsContext")
 local Sift = require("@pkg/Sift")
 local StoryControls = require("@root/Storybook/StoryControls")
 local StoryError = require("@root/Storybook/StoryError")
@@ -26,11 +27,13 @@ type Props = {
 
 local function StoryView(props: Props)
 	local theme = useTheme()
+	local settingsContext = SettingsContext.use()
 	local story, storyErr = useStory(props.story, props.storybook, props.loader)
 	local zoom = useZoom(props.story)
 	local plugin = React.useContext(PluginContext.Context)
 	local extraControls, setExtraControls = React.useState({})
-	local controlsHeight, setControlsHeight = React.useState(constants.CONTROLS_INITIAL_HEIGHT)
+	local initialControlsHeight = settingsContext.getSetting("controlsHeight")
+	local controlsHeight, setControlsHeight = React.useState(initialControlsHeight)
 	local topbarHeight, setTopbarHeight = React.useState(0)
 	local storyParentRef = React.useRef(nil :: GuiObject?)
 	local controls
@@ -168,7 +171,7 @@ local function StoryView(props: Props)
 
 			StoryControlsWrapper = showControls and e(ResizablePanel, {
 				layoutOrder = 3,
-				initialSize = UDim2.new(1, 0, 0, constants.CONTROLS_INITIAL_HEIGHT),
+				initialSize = UDim2.new(1, 0, 0, initialControlsHeight),
 				dragHandles = { "Top" },
 				minSize = Vector2.new(0, constants.CONTROLS_MIN_HEIGHT),
 				maxSize = Vector2.new(math.huge, constants.CONTROLS_MAX_HEIGHT),

--- a/src/UserSettings/SettingRow.luau
+++ b/src/UserSettings/SettingRow.luau
@@ -52,8 +52,6 @@ local function SettingRow(props: Props)
 			return React.createElement(InputField, {
 				placeholder = props.setting.value,
 				onSubmit = function(newValue, isValidOnSubmit)
-					print("newValue", newValue)
-					print("isValidOnSubmit", isValidOnSubmit)
 					if newValue == "" then
 						setSetting(nil)
 					else

--- a/src/UserSettings/SettingRow.luau
+++ b/src/UserSettings/SettingRow.luau
@@ -3,6 +3,7 @@ local Sift = require("@pkg/Sift")
 
 local Checkbox = require("@root/Forms/Checkbox")
 local Dropdown = require("@root/Forms/Dropdown")
+local InputField = require("@root/Forms/InputField")
 local SettingsContext = require("@root/UserSettings/SettingsContext")
 local defaultSettings = require("@root/UserSettings/defaultSettings")
 local nextLayoutOrder = require("@root/Common/nextLayoutOrder")
@@ -10,6 +11,7 @@ local useTheme = require("@root/Common/useTheme")
 
 local useCallback = React.useCallback
 local useMemo = React.useMemo
+local useState = React.useState
 
 local CHANGE_INDICATOR_WIDTH_PX = 2
 
@@ -22,8 +24,9 @@ export type Props = {
 }
 
 local function SettingRow(props: Props)
-	local settingsContext = SettingsContext.use()
 	local theme = useTheme()
+	local settingsContext = SettingsContext.use()
+	local isValid, setIsValid = useState(true)
 
 	local setSetting = useCallback(function(newValue: any)
 		settingsContext.setSetting(props.setting.name, newValue)
@@ -43,6 +46,36 @@ local function SettingRow(props: Props)
 				end),
 				onOptionChange = setSetting,
 			})
+		elseif props.setting.settingType == "number" then
+			local range = props.setting.range
+
+			return React.createElement(InputField, {
+				placeholder = props.setting.value,
+				onSubmit = function(newValue, isValidOnSubmit)
+					print("newValue", newValue)
+					print("isValidOnSubmit", isValidOnSubmit)
+					if newValue == "" then
+						setSetting(nil)
+					else
+						setIsValid(isValidOnSubmit)
+						setSetting(tonumber(newValue))
+					end
+				end,
+				validate = function(text)
+					local n = tonumber(text)
+					if n == nil then
+						return false
+					end
+
+					if range then
+						if n < range.Min or n > range.Max then
+							return false
+						end
+					end
+
+					return true
+				end,
+			})
 		end
 		error(`no handling for setting type {props.setting.settingType}`)
 	end, { props.setting, setSetting })
@@ -60,7 +93,7 @@ local function SettingRow(props: Props)
 			then React.createElement("Frame", {
 				Size = UDim2.new(0, CHANGE_INDICATOR_WIDTH_PX, 1, 0),
 				BorderSizePixel = 0,
-				BackgroundColor3 = theme.selection,
+				BackgroundColor3 = if isValid then theme.selection else theme.alert,
 			})
 			else nil,
 
@@ -103,6 +136,7 @@ local function SettingRow(props: Props)
 					TextSize = theme.textSize,
 					TextXAlignment = Enum.TextXAlignment.Left,
 					TextYAlignment = Enum.TextYAlignment.Top,
+					TextTruncate = Enum.TextTruncate.AtEnd,
 				}),
 
 				Description = React.createElement("TextLabel", {
@@ -116,6 +150,7 @@ local function SettingRow(props: Props)
 					TextSize = theme.textSize,
 					TextXAlignment = Enum.TextXAlignment.Left,
 					TextYAlignment = Enum.TextYAlignment.Top,
+					TextWrapped = true,
 				}),
 			}),
 

--- a/src/UserSettings/SettingsContext.luau
+++ b/src/UserSettings/SettingsContext.luau
@@ -62,9 +62,12 @@ local function Provider(props: Props)
 	end, { plugin, getSettingDefault })
 
 	local setSetting = useCallback(function(settingName: string, newValue: any)
+		if newValue == nil then
+			newValue = getSettingDefault(settingName)
+		end
 		plugin:SetSetting(settingName, newValue)
 		setSettings(loadSettingsFromDisk)
-	end, { plugin, loadSettingsFromDisk })
+	end, { plugin, loadSettingsFromDisk, getSettingDefault })
 
 	local getSetting = useCallback(function(settingName: string)
 		return settings[settingName].value

--- a/src/UserSettings/SettingsContext.spec.luau
+++ b/src/UserSettings/SettingsContext.spec.luau
@@ -45,7 +45,7 @@ describe("hook", function()
 	end)
 
 	test("local plugin settings override defaults", function()
-		mockPlugin:SetSetting("rememberLastOpenedStory", false)
+		mockPlugin:SetSetting("sidebarWidth", 400)
 
 		local get = renderHook(function()
 			return SettingsContext.use()
@@ -55,7 +55,7 @@ describe("hook", function()
 
 		local settingsContext = get()
 
-		expect(settingsContext.settings.rememberLastOpenedStory.value).toBe(false)
+		expect(settingsContext.settings.sidebarWidth.value).toBe(400)
 	end)
 
 	test("set setting value via context", function()
@@ -67,14 +67,14 @@ describe("hook", function()
 
 		local settingsContext = get()
 
-		expect(settingsContext.settings.rememberLastOpenedStory.value).toBe(true)
+		expect(settingsContext.settings.sidebarWidth.value).toBe(260)
 
 		act(function()
-			settingsContext.setSetting("rememberLastOpenedStory", false)
+			settingsContext.setSetting("sidebarWidth", 400)
 		end)
 
 		settingsContext = get()
 
-		expect(settingsContext.settings.rememberLastOpenedStory.value).toBe(false)
+		expect(settingsContext.settings.sidebarWidth.value).toBe(400)
 	end)
 end)

--- a/src/UserSettings/defaultSettings.luau
+++ b/src/UserSettings/defaultSettings.luau
@@ -30,7 +30,7 @@ type NumberSetting = BaseSetting & {
 	value: number,
 }
 
-export type Setting = CheckboxSetting | DropdownSetting
+export type Setting = CheckboxSetting | DropdownSetting | NumberSetting
 
 -- local expandNodesOnStart: Setting = {
 -- 	name = "expandNodesOnStart",

--- a/src/UserSettings/defaultSettings.luau
+++ b/src/UserSettings/defaultSettings.luau
@@ -1,4 +1,6 @@
-export type SettingType = "checkbox" | "dropdown"
+local constants = require("@root/constants")
+
+export type SettingType = "checkbox" | "dropdown" | "number"
 
 export type SettingChoice = {
 	name: string,
@@ -20,6 +22,12 @@ type CheckboxSetting = BaseSetting & {
 type DropdownSetting = BaseSetting & {
 	settingType: "dropdown",
 	choices: { SettingChoice },
+}
+
+type NumberSetting = BaseSetting & {
+	settingType: "number",
+	range: NumberRange?,
+	value: number,
 }
 
 export type Setting = CheckboxSetting | DropdownSetting
@@ -74,10 +82,30 @@ local theme: Setting = {
 	},
 }
 
+local sidebarWidth: NumberSetting = {
+	name = "sidebarWidth",
+	displayName = "Sidebar panel width",
+	description = `The default width (in pixels) of the sidebar. This can be between {constants.SIDEBAR_MIN_WIDTH}-{constants.SIDEBAR_MAX_WIDTH} px`,
+	settingType = "number",
+	range = NumberRange.new(constants.SIDEBAR_MIN_WIDTH, constants.SIDEBAR_MAX_WIDTH),
+	value = constants.SIDEBAR_INITIAL_WIDTH,
+}
+
+local controlsHeight: NumberSetting = {
+	name = "controlsHeight",
+	displayName = "Controls panel height",
+	description = `The default height (in pixels) of the 'Controls' panel. This can be between {constants.CONTROLS_MIN_HEIGHT}-{constants.CONTROLS_MAX_HEIGHT} px`,
+	settingType = "number",
+	range = NumberRange.new(constants.CONTROLS_MIN_HEIGHT, constants.CONTROLS_MAX_HEIGHT),
+	value = constants.CONTROLS_INITIAL_HEIGHT,
+}
+
 local settings = {
 	-- expandNodesOnStart = expandNodesOnStart,
 	-- rememberLastOpenedStory = rememberLastOpenedStory,
 	theme = theme,
+	sidebarWidth = sidebarWidth,
+	controlsHeight = controlsHeight,
 }
 
 export type Settings = typeof(settings)


### PR DESCRIPTION
# Problem

Panels like the sidebar and controls can be dragged to grow/shrink them, but there's no way to have this persist

# Solution

I've added two new settings to configure the width of the sidebar and the height of the controls panels. While clicking and dragging the panels won't have the size remembered, this at least allows users to set a default that works for them

# Checklist

- [ ] Ran `lune run test` locally before merging
