### PR TITLE
Bump ModuleLoader to 0.6.2

### DIFF
--- a/wally.toml
+++ b/wally.toml
@@ -7,7 +7,7 @@ realm = "shared"
 exclude = ["*"]
 
 [dependencies]
-ModuleLoader = "flipbook-labs/module-loader@0.6.1"
+ModuleLoader = "flipbook-labs/module-loader@0.6.2"
 React = "jsdotlua/react@17.0.2"
 ReactRoblox = "jsdotlua/react-roblox@17.0.2"
 ReactSpring = "chriscerie/react-spring@2.0.0"


### PR DESCRIPTION
ModuleLoader has been updated with improved types. This PR consumes it

# Checklist

- [x] Ran `lune run test` locally before merging
