### PR TITLE
Fix bug where NoStorySelected never renders

### DIFF
--- a/src/Navigation/Screen.luau
+++ b/src/Navigation/Screen.luau
@@ -4,6 +4,7 @@ local Storyteller = require("@pkg/Storyteller")
 
 local AboutView = require("@root/About/AboutView")
 local NavigationContext = require("@root/Navigation/NavigationContext")
+local NoStorySelected = require("@root/Storybook/NoStorySelected")
 local SettingsView = require("@root/UserSettings/SettingsView")
 local StoryCanvas = require("@root/Storybook/StoryCanvas")
 
@@ -30,6 +31,8 @@ local function Screen(props: Props)
 					story = props.story,
 					storybook = props.storybook,
 				})
+			else
+				return React.createElement(NoStorySelected)
 			end
 		elseif currentScreen == "Settings" then
 			return React.createElement(SettingsView)

--- a/src/Storybook/StoryCanvas.luau
+++ b/src/Storybook/StoryCanvas.luau
@@ -2,7 +2,6 @@ local ModuleLoader = require("@pkg/ModuleLoader")
 local React = require("@pkg/React")
 local Storyteller = require("@pkg/Storyteller")
 
-local NoStorySelected = require("@root/Storybook/NoStorySelected")
 local StoryView = require("@root/Storybook/StoryView")
 local useTheme = require("@root/Common/useTheme")
 
@@ -48,8 +47,6 @@ local function Canvas(props: Props)
 				story = props.story,
 				storybook = props.storybook,
 			}),
-
-			NoStorySelected = not props.story and e(NoStorySelected),
 		}),
 	})
 end


### PR DESCRIPTION
# Problem

When no story is selected we used to have a message displayed

# Solution

Simply changed where NoStorySelected is rendered. Works now!

Resolves #302 

# Checklist

- [x] Ran `lune run test` locally before merging
