### PR TITLE
Return home when navigating to same view

### DIFF
--- a/src/Panels/Topbar.luau
+++ b/src/Panels/Topbar.luau
@@ -17,12 +17,20 @@ local function Topbar(props: Props)
 	local navigation = NavigationContext.use()
 
 	local navigateToSettings = useCallback(function()
-		navigation.navigateTo("Settings")
-	end, { navigation.navigateTo })
+		if navigation.currentScreen ~= "Settings" then
+			navigation.navigateTo("Settings")
+		else
+			navigation.navigateTo("Home")
+		end
+	end, { navigation.navigateTo, navigation.currentScreen } :: { unknown })
 
 	local navigateToAbout = useCallback(function()
-		navigation.navigateTo("About")
-	end, { navigation.navigateTo })
+		if navigation.currentScreen ~= "About" then
+			navigation.navigateTo("About")
+		else
+			navigation.navigateTo("Home")
+		end
+	end, { navigation.navigateTo, navigation.currentScreen } :: { unknown })
 
 	return React.createElement("Frame", {
 		BackgroundColor3 = theme.sidebar,


### PR DESCRIPTION
# Problem

When navigating to About or Settings it feels like toggling the same button should do something. Right now it does not

# Solution

When toggling the same screen, return home. This feels a bit better on the UX side

Resolves #281

# Checklist

- [x] Ran `lune run test` locally before merging
