### PR TITLE
Update Storyteller to v0.6.0

### DIFF
--- a/src/Plugin/PluginApp.luau
+++ b/src/Plugin/PluginApp.luau
@@ -64,7 +64,7 @@ local function App(props: Props)
 			Sidebar = React.createElement(Sidebar, {
 				selectStory = selectStory,
 				selectStorybook = selectStorybook,
-				storybooks = storybooks,
+				storybooks = storybooks.available,
 			}),
 		}),
 

--- a/wally.toml
+++ b/wally.toml
@@ -8,7 +8,7 @@ exclude = ["*"]
 
 [dependencies]
 ModuleLoader = "flipbook-labs/module-loader@0.6.2"
-Storyteller = "flipbook-labs/storyteller@0.5.0"
+Storyteller = "flipbook-labs/storyteller@0.6.0"
 React = "jsdotlua/react@17.0.2"
 ReactRoblox = "jsdotlua/react-roblox@17.0.2"
 ReactSpring = "chriscerie/react-spring@2.0.0"


### PR DESCRIPTION
# Problem

Storyteller has some updates for nameless storybooks and a QOL change to useStorybooks that we'd like to consume

# Solution

Bumped Storyteller to v0.6.0 and updated usage of useStorybooks to be compatible

# Checklist

- [x] Ran `lune run test` locally before merging
