### PR TITLE
Bundle packages with the build files

### DIFF
--- a/.lune/build.luau
+++ b/.lune/build.luau
@@ -17,7 +17,9 @@ assert(typeof(output) == "string", `bad value for output (string expected, got {
 local function build()
 	compile(target)
 
-	run("rojo", { "build", "-o", output })
+	local dest = `{constants.BUILD_PATH}/{constants.PLUGIN_FILENAME}`
+	run("rojo", { "build", "-o", dest })
+	run("cp", { dest, output })
 end
 
 build()

--- a/.lune/lib/compile.luau
+++ b/.lune/lib/compile.luau
@@ -14,10 +14,12 @@ local PRUNED_FILES = {
 }
 
 local function compile(target: Target)
-	if fs.isDir(constants.BUILD_PATH) then
-		fs.removeDir(constants.BUILD_PATH)
+	local dest = `{constants.BUILD_PATH}/plugin`
+
+	if fs.isDir(dest) then
+		fs.removeDir(dest)
 	end
-	fs.writeDir(constants.BUILD_PATH)
+	fs.writeDir(dest)
 
 	local commitHash = run("git", { "rev-parse", "--short", "HEAD" })
 
@@ -39,7 +41,7 @@ local function compile(target: Target)
 	run("darklua", {
 		"process",
 		constants.SOURCE_PATH,
-		constants.BUILD_PATH,
+		dest,
 	}, {
 		env = env,
 	})
@@ -48,7 +50,7 @@ local function compile(target: Target)
 		run("darklua", {
 			"process",
 			"example",
-			`{constants.BUILD_PATH}/Example`,
+			`{dest}/Example`,
 		}, {
 			env = env,
 		})
@@ -56,12 +58,12 @@ local function compile(target: Target)
 
 	if target == "prod" then
 		for _, pattern in PRUNED_FILES do
-			run("find", { constants.BUILD_PATH, "-type", "f", "-name", pattern, "-delete" })
+			run("find", { dest, "-type", "f", "-name", pattern, "-delete" })
 		end
 	end
 
-	run("cp", { "-R", "Packages", constants.BUILD_PATH })
-	run("cp", { "-R", "RobloxPackages", constants.BUILD_PATH })
+	run("cp", { "-R", "Packages", dest })
+	run("cp", { "-R", "RobloxPackages", dest })
 end
 
 return compile

--- a/.lune/lib/compile.luau
+++ b/.lune/lib/compile.luau
@@ -59,6 +59,9 @@ local function compile(target: Target)
 			run("find", { constants.BUILD_PATH, "-type", "f", "-name", pattern, "-delete" })
 		end
 	end
+
+	run("cp", { "-R", "Packages", constants.BUILD_PATH })
+	run("cp", { "-R", "RobloxPackages", constants.BUILD_PATH })
 end
 
 return compile

--- a/default.project.json
+++ b/default.project.json
@@ -1,12 +1,6 @@
 {
   "name": "Flipbook",
   "tree": {
-    "Packages": {
-      "$path": "Packages"
-    },
-    "RobloxPackages": {
-      "$path": "RobloxPackages"
-    },
     "$path": "build"
   }
 }

--- a/default.project.json
+++ b/default.project.json
@@ -1,6 +1,6 @@
 {
   "name": "Flipbook",
   "tree": {
-    "$path": "build"
+    "$path": "build/plugin"
   }
 }


### PR DESCRIPTION
# Problem

For #290 I need to get an accurate snapshot of the entire plugin in plain files. Our rbxm gets built with all of the packages, but I can't work with the rbxm in this case

# Solution

I setup the build system so that Rojo isn't doing any stitching together. The final build is output to `build/plugin` including a copy of all of the packages that are required
