### PR TITLE
Add option to build for Rotriever

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           echo "MODEL_FILE=$name-$sha.rbxm" >> $GITHUB_ENV
 
       - name: Build
-        run: lune run build --target prod --output ${{ env.MODEL_FILE }}
+        run: lune run build --channel prod --output ${{ env.MODEL_FILE }}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         run: lune run install
 
       - name: Build
-        run: lune run build --target prod --output ${{ env.MODEL_FILE }}
+        run: lune run build --channel prod --output ${{ env.MODEL_FILE }}
 
       - uses: softprops/action-gh-release@v1
         if: ${{ github.event.release }}
@@ -55,8 +55,8 @@ jobs:
 
       - name: Publish nightly build to Creator Store
         if: github.ref == 'refs/heads/main'
-        run: lune run publish-plugin --target dev --apiKey ${{ secrets.ROBLOX_API_KEY }}
+        run: lune run publish-plugin --channel dev --apiKey ${{ secrets.ROBLOX_API_KEY }}
 
       - name: Publish release to Creator Store
         if: github.event.release
-        run: lune run publish-plugin --target prod --apiKey ${{ secrets.ROBLOX_API_KEY }}
+        run: lune run publish-plugin --channel prod --apiKey ${{ secrets.ROBLOX_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,9 @@ globalTypes.d.luau
 # Wally
 DevPackages
 Packages
-wally.lock
+
+# Package managers
+*.lock
 
 # Rbxasset
 LunePackages

--- a/.lune/build.luau
+++ b/.lune/build.luau
@@ -12,11 +12,17 @@ local args = parseArgs(process.args)
 local channel = if args.channel then args.channel else "prod"
 assert(channel == "dev" or channel == "prod", `bad value for channel (must be one of "dev" or "prod", got "{channel}")`)
 
+local target = if args.target then args.target else "roblox"
+assert(
+	target == "roblox" or target == "rotriever",
+	`bad value for target (must be one of "roblox" or "rotriever", got "{target}")`
+)
+
 local output = if args.output then args.output else `{roblox.studioPluginPath()}/{project.PLUGIN_FILENAME}`
 assert(typeof(output) == "string", `bad value for output (string expected, got {typeof(output)})`)
 
 local function build()
-	compile(channel)
+	compile(channel, target)
 
 	local dest = `{project.BUILD_PATH}/{project.PLUGIN_FILENAME}`
 	run("rojo", { "build", "-o", dest })

--- a/.lune/build.luau
+++ b/.lune/build.luau
@@ -9,14 +9,14 @@ local watch = require("./lib/watcher/watch")
 
 local args = parseArgs(process.args)
 
-local target = if args.target then args.target else "prod"
-assert(target == "dev" or target == "prod", `bad value for target (must be one of "dev" or "prod", got "{target}")`)
+local channel = if args.channel then args.channel else "prod"
+assert(channel == "dev" or channel == "prod", `bad value for channel (must be one of "dev" or "prod", got "{channel}")`)
 
 local output = if args.output then args.output else `{roblox.studioPluginPath()}/{project.PLUGIN_FILENAME}`
 assert(typeof(output) == "string", `bad value for output (string expected, got {typeof(output)})`)
 
 local function build()
-	compile(target)
+	compile(channel)
 
 	local dest = `{project.BUILD_PATH}/{project.PLUGIN_FILENAME}`
 	run("rojo", { "build", "-o", dest })

--- a/.lune/lib/compile.luau
+++ b/.lune/lib/compile.luau
@@ -21,6 +21,39 @@ local PROD_CONFIG = {
 	},
 }
 
+local function compileWorkspaceMember(memberPath: string, channel: Channel, env: { [string]: any }): string
+	local memberBuildPath = `{memberPath}/build`
+
+	if fs.isDir(memberBuildPath) then
+		fs.removeDir(memberBuildPath)
+	end
+	fs.writeDir(memberBuildPath)
+
+	run("darklua", {
+		"process",
+		`{memberPath}/src`,
+		memberBuildPath,
+	}, {
+		env = env,
+	})
+
+	local packagesPath = `{memberPath}/Packages`
+	run("cp", { "-R", packagesPath, `{memberBuildPath}/Packages` })
+
+	local robloxPackagesPath = `{memberPath}/RobloxPackages`
+	if fs.isDir(robloxPackagesPath) then
+		run("cp", { "-R", robloxPackagesPath, `{memberBuildPath}/RobloxPackages` })
+	end
+
+	if channel == "prod" then
+		for _, pattern in PROD_CONFIG.prunedFiles do
+			run("find", { memberBuildPath, "-type", "f", "-name", pattern, "-delete" })
+		end
+	end
+
+	return memberBuildPath
+end
+
 local function compile(channel: Channel)
 	local dest = `{project.BUILD_PATH}/plugin`
 
@@ -57,34 +90,17 @@ local function compile(channel: Channel)
 	for _, member in fs.readDir(project.WORKSPACE_PATH) do
 		local memberPath = `{project.WORKSPACE_PATH}/{member}`
 
-		if not fs.isDir(memberPath) then
-			continue
-		end
+		if fs.isDir(memberPath) then
+			local memberBuildPath = compileWorkspaceMember(memberPath, channel, env)
 
-		run("darklua", {
-			"process",
-			`{memberPath}/src`,
-			`{dest}/{memberPath}`,
-		}, {
-			env = env,
-		})
-
-		local packagesPath = `{memberPath}/Packages`
-		run("cp", { "-R", packagesPath, `{dest}/{packagesPath}` })
-
-		local robloxPackagesPath = `{memberPath}/RobloxPackages`
-		if fs.isDir(robloxPackagesPath) then
-			run("cp", { "-R", robloxPackagesPath, `{dest}/{robloxPackagesPath}` })
+			run("mkdir", { "-p", `{dest}/{memberPath}` })
+			run("cp", { "-R", `{memberBuildPath}/*`, `{dest}/{memberPath}` })
 		end
 	end
 
 	if channel == "prod" then
 		for _, dir in PROD_CONFIG.prunedDirs do
 			run("rm", { "-rf", `{dest}/{dir}` })
-		end
-
-		for _, pattern in PROD_CONFIG.prunedFiles do
-			run("find", { dest, "-type", "f", "-name", pattern, "-delete" })
 		end
 	end
 end

--- a/.lune/lib/compile.luau
+++ b/.lune/lib/compile.luau
@@ -5,7 +5,7 @@ local serde = require("@lune/serde")
 
 local wallyToml = serde.decode("toml", fs.readFile("wally.toml"))
 
-type Target = "prod" | "dev"
+type Channel = "prod" | "dev"
 
 local PROD_CONFIG = {
 	prunedDirs = {
@@ -21,7 +21,7 @@ local PROD_CONFIG = {
 	},
 }
 
-local function compile(target: Target)
+local function compile(channel: Channel)
 	local dest = `{project.BUILD_PATH}/plugin`
 
 	if fs.isDir(dest) then
@@ -33,7 +33,7 @@ local function compile(target: Target)
 
 	local env = {
 		BUILD_VERSION = wallyToml.package.version,
-		BUILD_CHANNEL = if target == "prod" then "production" else "development",
+		BUILD_CHANNEL = if channel == "prod" then "production" else "development",
 		BUILD_HASH = commitHash,
 	}
 
@@ -78,7 +78,7 @@ local function compile(target: Target)
 		end
 	end
 
-	if target == "prod" then
+	if channel == "prod" then
 		for _, dir in PROD_CONFIG.prunedDirs do
 			run("rm", { "-rf", `{dest}/{dir}` })
 		end

--- a/.lune/lib/compile.luau
+++ b/.lune/lib/compile.luau
@@ -1,11 +1,14 @@
 local fs = require("@lune/fs")
 local project = require("@repo/project")
-local run = require("./run")
 local serde = require("@lune/serde")
+
+local find = require("./find")
+local run = require("./run")
 
 local wallyToml = serde.decode("toml", fs.readFile("wally.toml"))
 
 type Channel = "prod" | "dev"
+type Target = "roblox" | "rotriever"
 
 local PROD_CONFIG = {
 	prunedDirs = {
@@ -21,7 +24,12 @@ local PROD_CONFIG = {
 	},
 }
 
-local function compileWorkspaceMember(memberPath: string, channel: Channel, env: { [string]: any }): string
+local function compileWorkspaceMember(
+	memberPath: string,
+	channel: Channel,
+	target: Target,
+	env: { [string]: any }
+): string
 	local memberBuildPath = `{memberPath}/build`
 
 	if fs.isDir(memberBuildPath) then
@@ -51,10 +59,19 @@ local function compileWorkspaceMember(memberPath: string, channel: Channel, env:
 		end
 	end
 
+	if target == "rotriever" then
+		-- Rotriever does not support .luau files, so rename them to .lua for
+		-- compatibility
+		for _, luauFile in find(memberBuildPath, "%.luau$") do
+			local newName = luauFile:gsub("%.luau$", ".lua")
+			fs.move(luauFile, newName)
+		end
+	end
+
 	return memberBuildPath
 end
 
-local function compile(channel: Channel)
+local function compile(channel: Channel, target: Target)
 	local dest = `{project.BUILD_PATH}/plugin`
 
 	if fs.isDir(dest) then
@@ -91,7 +108,7 @@ local function compile(channel: Channel)
 		local memberPath = `{project.WORKSPACE_PATH}/{member}`
 
 		if fs.isDir(memberPath) then
-			local memberBuildPath = compileWorkspaceMember(memberPath, channel, env)
+			local memberBuildPath = compileWorkspaceMember(memberPath, channel, target, env)
 
 			run("mkdir", { "-p", `{dest}/{memberPath}` })
 			run("cp", { "-R", `{memberBuildPath}/*`, `{dest}/{memberPath}` })

--- a/.lune/lib/find.luau
+++ b/.lune/lib/find.luau
@@ -1,8 +1,6 @@
 local fs = require("@lune/fs")
 
-type Matcher = string | (path: string) -> boolean
-
-local function find(root: string, matcher: Matcher): { string }
+local function find(root: string, pattern: string): { string }
 	local matches: { string } = {}
 
 	local function search(path: string)
@@ -12,14 +10,8 @@ local function find(root: string, matcher: Matcher): { string }
 				search(childPath)
 			end
 		else
-			if typeof(matcher) == "string" then
-				if path:match(matcher) then
-					table.insert(matches, path)
-				end
-			else
-				if matcher(path) then
-					table.insert(matches, path)
-				end
+			if path:match(pattern) then
+				table.insert(matches, path)
 			end
 		end
 	end

--- a/.lune/lib/find.luau
+++ b/.lune/lib/find.luau
@@ -1,0 +1,32 @@
+local fs = require("@lune/fs")
+
+type Matcher = string | (path: string) -> boolean
+
+local function find(root: string, matcher: Matcher): { string }
+	local matches: { string } = {}
+
+	local function search(path: string)
+		if fs.isDir(path) then
+			for _, child in fs.readDir(path) do
+				local childPath = `{path}/{child}`
+				search(childPath)
+			end
+		else
+			if typeof(matcher) == "string" then
+				if path:match(matcher) then
+					table.insert(matches, path)
+				end
+			else
+				if matcher(path) then
+					table.insert(matches, path)
+				end
+			end
+		end
+	end
+
+	search(root)
+
+	return matches
+end
+
+return find

--- a/.lune/publish-plugin.luau
+++ b/.lune/publish-plugin.luau
@@ -6,14 +6,14 @@ local run = require("./lib/run")
 
 local args = parseArgs(process.args)
 
-local target = if args.target then args.target else "dev"
-assert(target == "dev" or target == "prod", `bad value for target (must be one of "dev" or "prod", got "{target}")`)
+local channel = if args.channel then args.channel else "dev"
+assert(channel == "dev" or channel == "prod", `bad value for channel (must be one of "dev" or "prod", got "{channel}")`)
 
 local apiKey = assert(args.apiKey, "--apiKey must be supplied with a valid Open Cloud API key")
 assert(typeof(apiKey) == "string", `bad value for apiKey (string expected, got {typeof(apiKey)})`)
 
-run("lune", { "run", "build", "--target", target, "--output", "Flipbook.rbxm" })
+run("lune", { "run", "build", "--channel", channel, "--output", "Flipbook.rbxm" })
 
 -- Each of the assets defined in rbxasset.toml map to one of the options of
--- `--target` for simplicity
-rbxasset.publishPackageAsync(process.cwd, target, apiKey)
+-- `--channel` for simplicity
+rbxasset.publishPackageAsync(process.cwd, channel, apiKey)

--- a/.lune/test.luau
+++ b/.lune/test.luau
@@ -17,7 +17,7 @@ if not apiKey then
 	process.exit(1)
 end
 
-compile("dev")
+compile("dev", "roblox")
 
 run("rojo", { "build", "tests.project.json", "-o", "tests.rbxl" })
 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,7 +15,7 @@
       "type": "shell",
       "problemMatcher": [],
       "command": "lune",
-      "args": ["run", "build", "--target", "dev"],
+      "args": ["run", "build", "--channel", "dev"],
       "group": {
         "kind": "build",
         "isDefault": true
@@ -26,7 +26,7 @@
       "type": "shell",
       "problemMatcher": [],
       "command": "lune",
-      "args": ["run", "build", "--target", "prod"],
+      "args": ["run", "build", "--channel", "prod"],
       "group": {
         "kind": "build"
       }
@@ -36,7 +36,7 @@
       "type": "shell",
       "problemMatcher": [],
       "command": "lune",
-      "args": ["run", "build", "--target", "dev", "--watch"]
+      "args": ["run", "build", "--channel", "dev", "--watch"]
     },
     {
       "label": "Serve docs",

--- a/docs/docs/contributing/onboarding.md
+++ b/docs/docs/contributing/onboarding.md
@@ -44,10 +44,10 @@ lune run build
 
 Once built, open up a Baseplate to start interacting with the plugin.
 
-Production builds prune development files like unit test and Flipbook's own Storybook and Stories. To keep development files, pass the `--target` flag to set the environment to build for:
+Production builds prune development files like unit test and Flipbook's own Storybook and Stories. To keep development files, pass the `--channel` flag to set the environment to build for:
 
 ```sh
-lune run build --target dev
+lune run build --channel dev
 ```
 
 ### Build to rbxm


### PR DESCRIPTION
# Problem

We need some extra support to be able to publish flipbook-core to the Rotriever registry

# Solution

I've changed some of the terminology, `--target` has been renamed to `--channel` (for choosing between prod/dev), and a _new_ `--target` flag has been added to choose if we're building for Rotriever or not. This could be later extended for other package manages. For example it would be reasonable to have `wally` and `pesde` targets in the future.

Also each workspace member will now generate a `build` folder inside it. This makes it easier to deploy _just_ flipbook-core to the Rotriever registry, and is also just nice to be able to inspect a standalone build for each member
