### PR TITLE
Make the plugin button optional when creating the plugin

### DIFF
--- a/workspace/flipbook-core/src/Plugin/createFlipbookPlugin.luau
+++ b/workspace/flipbook-core/src/Plugin/createFlipbookPlugin.luau
@@ -7,7 +7,7 @@ local PluginApp = require("@root/Plugin/PluginApp")
 local function createFlipbookPlugin(
 	plugin: Plugin,
 	widget: DockWidgetPluginGui,
-	button: PluginToolbarButton
+	button: PluginToolbarButton?
 ): {
 	mount: () -> (),
 	unmount: () -> (),
@@ -30,19 +30,21 @@ local function createFlipbookPlugin(
 		root:render(app)
 	end
 
-	table.insert(
-		connections,
-		button.Click:Connect(function()
-			widget.Enabled = not widget.Enabled
-		end)
-	)
+	if button then
+		table.insert(
+			connections,
+			button.Click:Connect(function()
+				widget.Enabled = not widget.Enabled
+			end)
+		)
 
-	table.insert(
-		connections,
-		widget:GetPropertyChangedSignal("Enabled"):Connect(function()
-			button:SetActive(widget.Enabled)
-		end)
-	)
+		table.insert(
+			connections,
+			widget:GetPropertyChangedSignal("Enabled"):Connect(function()
+				button:SetActive(widget.Enabled)
+			end)
+		)
+	end
 
 	table.insert(
 		connections,

--- a/workspace/flipbook-core/src/Plugin/createFlipbookPlugin.luau
+++ b/workspace/flipbook-core/src/Plugin/createFlipbookPlugin.luau
@@ -30,7 +30,7 @@ local function createFlipbookPlugin(
 		root:render(app)
 	end
 
-	if button then
+	if button ~= nil then
 		table.insert(
 			connections,
 			button.Click:Connect(function()


### PR DESCRIPTION
# Problem

Hit an issue in StudioPlugins where there's not necessarily a toolbar button for the plugin to use

# Solution

This PR simply makes the toolbar button optional. Flipbook proper remains unchanged, this will be used by the built-in plugin
