### PR TITLE
Bump version to 2.5.0

### DIFF
--- a/.lute/bump-version.luau
+++ b/.lute/bump-version.luau
@@ -52,7 +52,6 @@ do
 	}
 
 	local bumpedVersionComponent = args:get("versionBump")
-	print("bumpedVersionComponent")
 	local versionBump: VersionComponent = validateVersionBump(bumpedVersionComponent)
 
 	-- The root Wally manifest is the source of truth for the current version

--- a/.lute/bump-version.luau
+++ b/.lute/bump-version.luau
@@ -66,7 +66,7 @@ do
 		local manifestVersion
 		if path.extname(manifestPath) == ".toml" then
 			manifestVersion = semver.getVersionFromManifest(manifestPath)
-		elseif path.extname(manifestPath) == ".luau" then
+		elseif path.basename(manifestPath) == "loom.config.luau" then
 			manifestVersion = loomConfig.package.version
 		else
 			error(`unsupported manifest file type for {manifestPath}`)

--- a/.lute/bump-version.luau
+++ b/.lute/bump-version.luau
@@ -1,7 +1,9 @@
 local cli = require("@luaupkg/batteries/cli")
 local fs = require("@std/fs")
+local path = require("@std/path")
 
 local findAndReplace = require("@scripts/lib/findAndReplace")
+local loomConfig = require("@repo/loom.config")
 local semver = require("@scripts/lib/semver")
 
 type VersionComponent = semver.VersionComponent
@@ -45,7 +47,7 @@ args:parse(argsNoScript)
 do
 	local MANIFEST_PATHS = {
 		"wally.toml",
-		"workspace/flipbook-core/wally.toml",
+		"loom.config.luau",
 		"workspace/flipbook-core/rotriever.toml",
 	}
 
@@ -61,7 +63,14 @@ do
 	local nextVersion = getNextVersion(currentVersion, versionBump)
 
 	for _, manifestPath in MANIFEST_PATHS do
-		local manifestVersion = semver.getVersionFromManifest(manifestPath)
+		local manifestVersion
+		if path.extname(manifestPath) == ".toml" then
+			manifestVersion = semver.getVersionFromManifest(manifestPath)
+		elseif path.extname(manifestPath) == ".luau" then
+			manifestVersion = loomConfig.package.version
+		else
+			error(`unsupported manifest file type for {manifestPath}`)
+		end
 
 		if fs.exists(manifestPath) then
 			findAndReplace(manifestPath, `version = "{manifestVersion}"`, `version = "{nextVersion}"`)

--- a/loom.config.luau
+++ b/loom.config.luau
@@ -1,7 +1,7 @@
 return {
 	package = {
 		name = "Flipbook",
-		version = "2.4.0",
+		version = "2.5.0",
 		dependencies = {
 			["flipbook-batteries"] = {
 				rev = "v0.7.0",

--- a/wally.toml
+++ b/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipbook-labs/flipbook"
-version = "2.4.0"
+version = "2.5.0"
 license = "MIT"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"

--- a/workspace/flipbook-core/rotriever.toml
+++ b/workspace/flipbook-core/rotriever.toml
@@ -1,7 +1,7 @@
 [package]
 name = "FlipbookCore"
 content_root = "build"
-version = "2.4.0"
+version = "2.5.0"
 files = ["*"]
 publish = true
 


### PR DESCRIPTION
# Problem

It's time for a new Flipbook release! First one of the year

# Solution

Bumped our various manifests to v2.5.0. 

Also updated the bump-version script to handle all the updates so we don't have to make them manually
