### PR TITLE
Remove large padding tag from preview

### DIFF
--- a/workspace/flipbook-core/src/Storybook/StoryView.luau
+++ b/workspace/flipbook-core/src/Storybook/StoryView.luau
@@ -123,7 +123,7 @@ local function StoryView(props: StoryViewProps)
 
 			Preview = e(View, {
 				LayoutOrder = 3,
-				tag = "padding-large shrink size-full",
+				tag = "shrink size-full",
 			}, {
 				StoryPreview = React.createElement(StoryPreview, {
 					story = story,


### PR DESCRIPTION
# Problem

Currently, there is unnecessary space around the preview, which is especially noticeable on small screens like my 13-inch laptop. It is unnecessary because it only pads the separator lines, which already distinctly separate UI sections.

## Before

<img width="850" height="577" alt="image" src="https://github.com/user-attachments/assets/73e8388a-babf-4c56-a7b0-10ff9d49ac8b" />

# Solution

This PR removes that padding by removing the `padding-large` style tag from the preview component.

## After

<img width="849" height="623" alt="image" src="https://github.com/user-attachments/assets/041633ee-2507-478b-9805-a5871fe68ba1" />
