### PR TITLE
Try to support fork workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment: strict
+    environment: sandbox
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request_target:
+    branches:
+      - main
 
 permissions:
   id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request_target:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,8 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment: sandbox
+    environment:
+      name: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) && 'luau-execution-gated' || 'luau-execution' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
 
 permissions:
   id-token: write
@@ -120,6 +120,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment: strict
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment:
+      # This giant expression makes it so forks of Flipbook go through a gated
+      # environment that must be approved, while internal contributions auto-run
+      # like normal.
       name: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) && 'luau-execution-gated' || 'luau-execution' }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Release
 
 on:
   pull_request_target:
+    branches:
+      - main
   release:
     types: [published]
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   publish-github-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 on:
-  pull_request:
+  pull_request_target:
   release:
     types: [published]
   push:


### PR DESCRIPTION
# Problem

Fork-based workflows are hitting failures in CI. We have some levers we can pull to make this a better experience, so let's try some things out

# Solution

We're now using `pull_request_target` which grants some extra permissions to the fork's jobs, and I've adjusted environments so that anything requiring `ROBLOX_API_KEY` must be approved before it can run
