### PR TITLE
Setup workflows to be dispatchable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 permissions:
   id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   publish-github-release:


### PR DESCRIPTION
# Problem

I'm trying to setup support for fork workflows in #559 but hit a wall where none of the required jobs are running. I think I can kickstart them with `workflow_dispatch` but it needs to exist on `main` for that to be possible

# Solution

Setup the CI and release workflows to be dispatchable from the GitHub UI.
