### PR TITLE
Fix dev deployments triggering for all PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       url: https://create.roblox.com/store/asset/8517129161
     env:
       LOG_LEVEL: debug
-    if: github.event.release
+    if: ${{ github.event.release }}
     steps:
       - uses: actions/checkout@v4
 
@@ -79,7 +79,7 @@ jobs:
       url: https://create.roblox.com/store/asset/88523969718241
     env:
       LOG_LEVEL: debug
-    if: github.ref == 'refs/heads/main'
+    if: ${{ ! github.event_name == 'pull_request_target' }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
# Problem

With the recent switch to pull_request_target (#559) we hit an issue where the development build was being deployed right from PRs.

# Solution

This is hopefully a simple condition change. Changing the intent from "deploy when run from `main`" (which is now always true) to "deploy for everything that's not a PR," which I believe in this case will match our same needs
