### PR TITLE
Fix smoketest deployments cancelling each other

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,3 +145,6 @@ jobs:
         run: lute run test
         env:
           ROBLOX_API_KEY: ${{ secrets.ROBLOX_API_KEY }}
+
+      - name: Deploy smoketest plugin to Creator Store
+        run: lune run publish-plugin --smoketest --channel prod --apiKey ${{ secrets.ROBLOX_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
   pull_request_target:
     branches:
       - main
-  pull_request:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request_target:
     branches:
       - main
+  pull_request:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
       url: https://create.roblox.com/store/asset/88523969718241
     env:
       LOG_LEVEL: debug
-    if: ${{ ! github.event_name == 'pull_request_target' }}
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,26 +92,3 @@ jobs:
 
       - name: Publish nightly build to Creator Store
         run: lune run publish-plugin --channel dev --apiKey ${{ secrets.ROBLOX_API_KEY }}
-
-  publish-smoketest-plugin:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    environment:
-      name: roblox-creator-store-smoketest
-    env:
-      LOG_LEVEL: debug
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: CompeyDev/setup-rokit@v0.1.2
-        with:
-          version: v1.1.1
-
-      - name: Install dependencies
-        run: lute run install
-
-      - name: Create .env
-        run: cp .env.template .env
-
-      - name: Publish release to Creator Store
-        run: lune run publish-plugin --smoketest --channel prod --apiKey ${{ secrets.ROBLOX_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,6 @@ jobs:
   publish-smoketest-plugin:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    concurrency: ${{ github.ref }}
     environment:
       name: roblox-creator-store-smoketest
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release
 
 on:
-  pull_request_target:
-    branches:
-      - main
   release:
     types: [published]
   push:


### PR DESCRIPTION
# Problem

We have concurrency setup for the plugin deployment smoketest but this seems to interact weirdly with deployment approvals. It makes sense for prod and dev deployments to be concurrent, but for the smoketest we don't care which plugin makes it to the Creator Store, we just want to know the flow succeeds

# Solution

I took care of the concurrency issue and while I was here I also wanted to make some revisions to how these workflows run.

I've changed it so now the Release workflow no longer runs on PRs at all. Mainly because I don't want to think about the blast radius of `pull_request_target` there. Since we still need the deployment smoketest to run I opted to put that in the `CI / tests` job, which I think make sense because this step is kind of an end-to-end test for plugin publishing.

This has the dual benefit of leveraging the same `luau-execution-gated` logic, too. I like this better since it keeps all the hair `pull_request_target` logic in the same place. _And_ one less deployment to have to approve