### PR TITLE
Isolate the surface area of `pull_request_target`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     branches:
       - main
   workflow_dispatch:
@@ -119,32 +119,3 @@ jobs:
 
       - name: Run Luau analysis
         run: lute run analyze
-
-  tests:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    environment:
-      # This giant expression makes it so forks of Flipbook go through a gated
-      # environment that must be approved, while internal contributions auto-run
-      # like normal.
-      name: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) && 'luau-execution-gated' || 'luau-execution' }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: CompeyDev/setup-rokit@v0.1.2
-        with:
-          version: v1.2.0
-
-      - name: Install dependencies
-        run: lute run install
-
-      - name: Create .env
-        run: cp .env.template .env
-
-      - name: Run tests
-        run: lute run test
-        env:
-          ROBLOX_API_KEY: ${{ secrets.ROBLOX_API_KEY }}
-
-      - name: Deploy smoketest plugin to Creator Store
-        run: lune run publish-plugin --smoketest --channel prod --apiKey ${{ secrets.ROBLOX_API_KEY }}

--- a/.github/workflows/strict.yml
+++ b/.github/workflows/strict.yml
@@ -23,7 +23,9 @@ jobs:
       # in this context.
       name: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) && 'luau-execution-gated' || 'luau-execution' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
 
       - uses: CompeyDev/setup-rokit@v0.1.2
         with:

--- a/.github/workflows/strict.yml
+++ b/.github/workflows/strict.yml
@@ -1,0 +1,44 @@
+name: Strict
+
+on:
+  # We use pull_request_target to allow jobs in this workflow to run with
+  # secrets, and each job is gated by an environment. The environment is chosen
+  # based on whether the PR is from a fork or not, so that internal exnternal
+  # contributions require approval, while internal ones run like normal.
+  pull_request_target:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      # This giant expression is unfortunately the best we can do right now. The
+      # hope was to offload it to an `env` variable, but those can't be accessed
+      # in this context.
+      name: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) && 'luau-execution-gated' || 'luau-execution' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: CompeyDev/setup-rokit@v0.1.2
+        with:
+          version: v1.2.0
+
+      - name: Install dependencies
+        run: lute run install
+
+      - name: Create .env
+        run: cp .env.template .env
+
+      - name: Run tests
+        run: lute run test
+        env:
+          ROBLOX_API_KEY: ${{ secrets.ROBLOX_API_KEY }}
+
+      - name: Deploy smoketest plugin to Creator Store
+        run: lune run publish-plugin --smoketest --channel prod --apiKey ${{ secrets.ROBLOX_API_KEY }}

--- a/project.luau
+++ b/project.luau
@@ -7,7 +7,7 @@ return {
 	BUILD_CACHE_PATH = path.resolve("./build/build-cache.json"),
 	PACKAGES_PATH = path.resolve("./Packages"),
 	ROBLOX_PACKAGES_PATH = path.resolve("./RobloxPackages"),
-	ROBLOX_PACKAGES_VERSION = "0.716.0.7160873",
+	ROBLOX_PACKAGES_VERSION = "0.715.1.7151119",
 	SCRIPTS_PATH = path.resolve("./.lute"),
 	EXAMPLE_PATH = path.resolve("./example"),
 	WORKSPACE_PATH = path.resolve("./workspace"),

--- a/wally.lock
+++ b/wally.lock
@@ -44,7 +44,7 @@ dependencies = []
 
 [[package]]
 name = "flipbook-labs/flipbook"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [["Charm", "littensy/charm@0.11.0-rc.4"], ["Fusion", "elttob/fusion@0.2.0"], ["Highlighter", "boatbomber/highlighter@0.9.0"], ["Jest", "jsdotlua/jest@3.10.0"], ["JestGlobals", "jsdotlua/jest-globals@3.10.0"], ["Log", "realthx1/luaulog@0.3.0"], ["LuauPolyfill", "jsdotlua/luau-polyfill@1.2.7"], ["ModuleLoader", "flipbook-labs/module-loader@0.10.2"], ["React", "jsdotlua/react@17.2.1"], ["ReactCharm", "littensy/react-charm@0.4.0-rc.3"], ["ReactRoblox", "jsdotlua/react-roblox@17.2.1"], ["ReactSpring", "chriscerie/react-spring@2.0.0"], ["Roact", "roblox/roact@1.4.4"], ["Sift", "csqrl/sift@0.0.8"], ["Storyteller", "flipbook-labs/storyteller@1.10.0"], ["sha256", "dekkonot/sha256@1.0.1"], ["t", "osyrisrblx/t@3.1.1"]]
 
 [[package]]


### PR DESCRIPTION
# Problem

I feel like I've been fighting up a stream trying to intermingle `pull_request_target` in our existing workflows. I think there's a better way I could be doing this.

Also tests started failing because of `pull_request_target` not checking out any of the changed code before running tests.

# Solution

I decided to just offload the part that requires secrets to a new workflow all together. Went back to just `pull_request` for the rest of the CI workflow.

Also fixed the issue with changes not getting checked out. I was thinking about tacking on an allowlist of paths that could be changed by a PR. But since the jobs in this workflow are intended to require manual approval (after reviewing the PR changes), this should be ok in practice

 Fingers crossed this helps with all the friction