### PR TITLE
Use a proper dotenv package

### DIFF
--- a/.lute/build.luau
+++ b/.lute/build.luau
@@ -1,5 +1,6 @@
 local FlipbookBatteries = require("@luaupkg/flipbook-batteries@v0.9.0")
 local cli = require("@luaupkg/lute@v1.0.0/batteries/cli")
+local dotenv = require("@luaupkg/dotenv@v0.1.0/src")
 local fs = require("@std/fs")
 local path = require("@std/path")
 local pp = require("@luaupkg/lute@v1.0.0/batteries/pp")
@@ -13,7 +14,6 @@ local getStudioPluginsPath = require("@scripts/lib/getStudioPluginsPath")
 local project = require("@repo/project")
 
 local copyInto = FlipbookBatteries.copyInto
-local dotenv = FlipbookBatteries.dotenv
 local run = FlipbookBatteries.run
 local watch = FlipbookBatteries.watch
 
@@ -21,7 +21,7 @@ local WALLY_MANIFEST_PATH = path.resolve("wally.toml")
 
 type BuildContext = buildSystem.BuildContext
 
-dotenv()
+dotenv.config()
 
 local args = cli.parser()
 

--- a/.lute/test.luau
+++ b/.lute/test.luau
@@ -1,15 +1,15 @@
 local FlipbookBatteries = require("@luaupkg/flipbook-batteries@v0.9.0")
 local cli = require("@luaupkg/lute@v1.0.0/batteries/cli")
+local dotenv = require("@luaupkg/dotenv@v0.1.0/src")
 local path = require("@std/path")
 local process = require("@std/process")
 local system = require("@std/system")
 
 local project = require("@repo/project")
 
-local dotenv = FlipbookBatteries.dotenv
 local run = FlipbookBatteries.run
 
-dotenv()
+dotenv.config()
 
 local args = cli.parser()
 

--- a/loom.config.luau
+++ b/loom.config.luau
@@ -13,6 +13,11 @@ return {
 				sourceKind = "github",
 				source = "https://github.com/luau-lang/lute",
 			},
+			["dotenv"] = {
+				rev = "v0.1.0",
+				sourceKind = "github",
+				source = "https://github.com/erlcx/lute-dotenv",
+			},
 		},
 	},
 }

--- a/loom.lock.luau
+++ b/loom.lock.luau
@@ -9,6 +9,14 @@ return {
       sourceKind = "github",
       dependencies = {},
     },
+    ["dotenv@v0.1.0"] = {
+      installPath = "Packages/dotenv@v0.1.0",
+      name = "dotenv",
+      rev = "v0.1.0",
+      source = "https://github.com/erlcx/lute-dotenv",
+      sourceKind = "github",
+      dependencies = {},
+    },
     ["flipbook-batteries@v0.9.0"] = {
       installPath = "Packages/flipbook-batteries@v0.9.0",
       name = "flipbook-batteries",
@@ -28,5 +36,5 @@ return {
       dependencies = {},
     },
   },
-  packages = {"flipbook-batteries@v0.9.0", "lute@v1.0.0"},
+  packages = {"flipbook-batteries@v0.9.0", "dotenv@v0.1.0", "lute@v1.0.0"},
 }


### PR DESCRIPTION
# Problem

I threw together [basic dotenv functionality in FlipbookBatteries](https://github.com/flipbook-labs/flipbook-batteries/blob/7a5bf190a91c45f0fb70c9cb977a867638151147/src/dotenv.luau) but it leaves much to be desired.

# Solution

Thankfully Lute has a package manager now! And there's a dotenv package! Let's use it!