### PR TITLE
Object control type

### DIFF
--- a/wally.lock
+++ b/wally.lock
@@ -45,7 +45,7 @@ dependencies = []
 [[package]]
 name = "flipbook-labs/flipbook"
 version = "2.5.0"
-dependencies = [["Charm", "littensy/charm@0.11.0-rc.4"], ["Fusion", "elttob/fusion@0.2.0"], ["Highlighter", "boatbomber/highlighter@0.9.0"], ["Jest", "jsdotlua/jest@3.10.0"], ["JestGlobals", "jsdotlua/jest-globals@3.10.0"], ["Log", "realthx1/luaulog@0.3.0"], ["LuauPolyfill", "jsdotlua/luau-polyfill@1.2.7"], ["ModuleLoader", "flipbook-labs/module-loader@0.10.2"], ["React", "jsdotlua/react@17.2.1"], ["ReactCharm", "littensy/react-charm@0.4.0-rc.3"], ["ReactRoblox", "jsdotlua/react-roblox@17.2.1"], ["ReactSpring", "chriscerie/react-spring@2.0.0"], ["Roact", "roblox/roact@1.4.4"], ["Sift", "csqrl/sift@0.0.8"], ["Storyteller", "flipbook-labs/storyteller@1.10.0"], ["sha256", "dekkonot/sha256@1.0.1"], ["t", "osyrisrblx/t@3.1.1"]]
+dependencies = [["Charm", "littensy/charm@0.11.0-rc.4"], ["Fusion", "elttob/fusion@0.2.0"], ["Highlighter", "boatbomber/highlighter@0.9.0"], ["Jest", "jsdotlua/jest@3.10.0"], ["JestGlobals", "jsdotlua/jest-globals@3.10.0"], ["Log", "realthx1/luaulog@0.3.0"], ["LuauPolyfill", "jsdotlua/luau-polyfill@1.2.7"], ["ModuleLoader", "flipbook-labs/module-loader@0.10.2"], ["React", "jsdotlua/react@17.2.1"], ["ReactCharm", "littensy/react-charm@0.4.0-rc.3"], ["ReactRoblox", "jsdotlua/react-roblox@17.2.1"], ["ReactSpring", "chriscerie/react-spring@2.0.0"], ["Roact", "roblox/roact@1.4.4"], ["Sift", "csqrl/sift@0.0.8"], ["Storyteller", "flipbook-labs/storyteller@1.11.0"], ["sha256", "dekkonot/sha256@1.0.1"], ["t", "osyrisrblx/t@3.1.1"]]
 
 [[package]]
 name = "flipbook-labs/module-loader"
@@ -54,7 +54,7 @@ dependencies = [["Jest", "jsdotlua/jest@3.10.0"], ["JestGlobals", "jsdotlua/jest
 
 [[package]]
 name = "flipbook-labs/storyteller"
-version = "1.10.0"
+version = "1.11.0"
 dependencies = [["Charm", "littensy/charm@0.11.0-rc.4"], ["Fusion", "elttob/fusion@0.2.0"], ["Fusion3", "elttob/fusion@0.3.0"], ["GreenTea", "corecii/greentea@0.4.11"], ["Jest", "jsdotlua/jest@3.10.0"], ["JestGlobals", "jsdotlua/jest-globals@3.10.0"], ["ModuleLoader", "flipbook-labs/module-loader@0.10.2"], ["React", "jsdotlua/react@17.2.1"], ["ReactCharm", "littensy/react-charm@0.4.0-rc.3"], ["ReactRoblox", "jsdotlua/react-roblox@17.2.1"], ["Roact", "roblox/roact@1.4.4"], ["RoactCompat", "jsdotlua/roact-compat@17.2.1"], ["Sift", "csqrl/sift@0.0.8"], ["UILabs", "pepeeltoro41/ui-labs@2.4.2"], ["t", "osyrisrblx/t@3.1.1"]]
 
 [[package]]

--- a/wally.toml
+++ b/wally.toml
@@ -18,7 +18,7 @@ ReactRoblox = "jsdotlua/react-roblox@17.0.2"
 ReactSpring = "chriscerie/react-spring@2.0.0"
 sha256 = "dekkonot/sha256@1.0.1"
 Sift = "csqrl/sift@0.0.8"
-Storyteller = "flipbook-labs/storyteller@1.10.0"
+Storyteller = "flipbook-labs/storyteller@1.11.0"
 t = "osyrisrblx/t@3.0.0"
 
 # dev dependencies

--- a/workspace/flipbook-core/src/StoryControls/ControlElements/ObjectControl.luau
+++ b/workspace/flipbook-core/src/StoryControls/ControlElements/ObjectControl.luau
@@ -22,20 +22,19 @@ local function ObjectControl(props: Props)
 	local currentValue = props.controlValue or props.controlSchema.default
 
 	local onActivated = useCallback(function()
-		-- When selected, this will deselect the input giving the user an escape
-		-- route.
 		if isSelecting then
 			setIsActive(false)
 			setIsSelecting(false)
-			return
-		end
-
-		if currentValue ~= nil then
-			props.onChanged(nil)
 		else
 			setIsSelecting(true)
 		end
-	end, { currentValue, isSelecting, props.onChanged } :: { unknown })
+	end, { isSelecting } :: { unknown })
+
+	local onClear = useCallback(function()
+		setIsActive(false)
+		setIsSelecting(false)
+		props.onChanged(nil)
+	end, { props.onChanged } :: { unknown })
 
 	local onStateChanged = useCallback(function(newState: Foundation.ControlState)
 		setIsActive(
@@ -45,9 +44,6 @@ local function ObjectControl(props: Props)
 			setIsSelecting(false)
 		end
 	end, {})
-
-	-- TODO: Don't clear the selection when picking again. Allow the user to
-	-- press Esc to deselect or click the selected instance again to deselect.
 
 	useEffect(function()
 		if not isSelecting then
@@ -115,7 +111,7 @@ local function ObjectControl(props: Props)
 			LayoutOrder = 2,
 			icon = buttonIcon,
 			size = Foundation.Enums.InputSize.XSmall,
-			onActivated = onActivated,
+			onActivated = if currentValue ~= nil then onClear else onActivated,
 		}),
 	})
 end

--- a/workspace/flipbook-core/src/StoryControls/ControlElements/ObjectControl.luau
+++ b/workspace/flipbook-core/src/StoryControls/ControlElements/ObjectControl.luau
@@ -39,10 +39,6 @@ local function ObjectControl(props: Props)
 		end
 	end, { currentValue, isSelecting, props.onChanged } :: { unknown })
 
-	local onBackdropActivated = useCallback(function()
-		setIsSelecting(false)
-	end, {})
-
 	local onStateChanged = useCallback(function(newState: Foundation.ControlState)
 		setIsActive(
 			newState == Foundation.Enums.ControlState.Hover or newState == Foundation.Enums.ControlState.Pressed
@@ -122,15 +118,6 @@ local function ObjectControl(props: Props)
 			icon = buttonIcon,
 			size = Foundation.Enums.InputSize.XSmall,
 			onActivated = onActivated,
-		}),
-
-		Backdrop = e(Foundation.Popover.Root, {
-			isOpen = isSelecting,
-		}, {
-			Content = e(Foundation.Popover.Content, {
-				hasArrow = false,
-				onPressedOutside = onBackdropActivated,
-			}),
 		}),
 	})
 

--- a/workspace/flipbook-core/src/StoryControls/ControlElements/ObjectControl.luau
+++ b/workspace/flipbook-core/src/StoryControls/ControlElements/ObjectControl.luau
@@ -91,20 +91,36 @@ local function ObjectControl(props: Props)
 		},
 		onActivated = onActivated,
 	}, {
-		ObjectLabel = e(Foundation.Text, {
-			tag = {
-				["auto-xy text-body-medium"] = true,
-				["content-muted"] = currentValue == nil,
-				["content-default"] = currentValue ~= nil,
-			},
-			LayoutOrder = 1,
-			Text = if currentValue then currentValue.Name else PLACEHOLDER,
-		}),
+		Placeholder = if not currentValue
+			then e(Foundation.Text, {
+				tag = "auto-x size-0-full content-muted text-body-medium",
+				LayoutOrder = 1,
+				Text = if currentValue then currentValue.Name else PLACEHOLDER,
+			})
+			else nil,
+
+		Selection = if currentValue
+			then e(Foundation.View, {
+				tag = "auto-xy col",
+			}, {
+				DisplayName = e(Foundation.Text, {
+					tag = "auto-xy content-default text-body-medium",
+					LayoutOrder = 1,
+					Text = currentValue.Name,
+				}),
+
+				FullName = e(Foundation.Text, {
+					tag = "auto-xy content-muted text-body-small",
+					LayoutOrder = 2,
+					Text = currentValue:GetFullName(),
+				}),
+			})
+			else nil,
 
 		PrimaryAction = e(Foundation.IconButton, {
 			LayoutOrder = 2,
 			icon = buttonIcon,
-			size = Foundation.Enums.InputSize.Small,
+			size = Foundation.Enums.InputSize.XSmall,
 			onActivated = onActivated,
 		}),
 
@@ -117,14 +133,6 @@ local function ObjectControl(props: Props)
 			}),
 		}),
 	})
-
-	if currentValue then
-		root = e(Foundation.Tooltip, {
-			title = currentValue:GetFullName(),
-			side = Foundation.Enums.PopoverSide.Top,
-			align = Foundation.Enums.PopoverAlign.Center,
-		}, root)
-	end
 
 	return root
 end

--- a/workspace/flipbook-core/src/StoryControls/ControlElements/ObjectControl.luau
+++ b/workspace/flipbook-core/src/StoryControls/ControlElements/ObjectControl.luau
@@ -15,7 +15,7 @@ export type Props = {
 	onChanged: (Instance?) -> (),
 }
 
-local PLACEHOLDER = "Click to pick..."
+local PLACEHOLDER = "Select an Instance"
 
 local function ObjectControl(props: Props)
 	local isSelecting, setIsSelecting = useState(false)
@@ -24,6 +24,8 @@ local function ObjectControl(props: Props)
 	local currentValue = props.controlValue or props.controlSchema.default
 
 	local onActivated = useCallback(function()
+		-- When selected, this will deselect the input giving the user an escape
+		-- route.
 		if isSelecting then
 			setIsActive(false)
 			setIsSelecting(false)
@@ -77,7 +79,7 @@ local function ObjectControl(props: Props)
 
 	local root: React.ReactElement<any> = e(Foundation.View, {
 		tag = {
-			["size-full-800 row align-y-center gap-small bg-shift-100 radius-medium padding-x-small stroke-position-inner"] = true,
+			["size-full-800 row align-y-center gap-small bg-shift-100 radius-medium padding-x-small flex-between stroke-position-inner"] = true,
 			["stroke-standard"] = not isActive,
 			["stroke-thick"] = isActive or isSelecting,
 			["stroke-default"] = not isSelecting,
@@ -91,10 +93,11 @@ local function ObjectControl(props: Props)
 	}, {
 		ObjectLabel = e(Foundation.Text, {
 			tag = {
-				["auto-xy fill text-body-medium"] = true,
+				["auto-xy text-body-medium"] = true,
 				["content-muted"] = currentValue == nil,
 				["content-default"] = currentValue ~= nil,
 			},
+			LayoutOrder = 1,
 			Text = if currentValue then currentValue.Name else PLACEHOLDER,
 		}),
 

--- a/workspace/flipbook-core/src/StoryControls/ControlElements/ObjectControl.luau
+++ b/workspace/flipbook-core/src/StoryControls/ControlElements/ObjectControl.luau
@@ -1,0 +1,129 @@
+local Selection = game:GetService("Selection")
+
+local Foundation = require("@rbxpkg/Foundation")
+local React = require("@pkg/React")
+local Storyteller = require("@pkg/Storyteller")
+
+local e = React.createElement
+local useCallback = React.useCallback
+local useEffect = React.useEffect
+local useState = React.useState
+
+export type Props = {
+	controlSchema: Storyteller.ObjectControl,
+	controlValue: Instance?,
+	onChanged: (Instance?) -> (),
+}
+
+local PLACEHOLDER = "Click to pick..."
+
+local function ObjectControl(props: Props)
+	local isSelecting, setIsSelecting = useState(false)
+	local isActive, setIsActive = useState(false)
+
+	local currentValue = props.controlValue or props.controlSchema.default
+
+	local onActivated = useCallback(function()
+		if isSelecting then
+			setIsActive(false)
+			setIsSelecting(false)
+			return
+		end
+
+		if currentValue ~= nil then
+			props.onChanged(nil)
+		else
+			setIsSelecting(true)
+		end
+	end, { currentValue, isSelecting, props.onChanged } :: { unknown })
+
+	local onBackdropActivated = useCallback(function()
+		setIsSelecting(false)
+	end, {})
+
+	local onStateChanged = useCallback(function(newState: Foundation.ControlState)
+		setIsActive(
+			newState == Foundation.Enums.ControlState.Hover or newState == Foundation.Enums.ControlState.Pressed
+		)
+		if newState == Foundation.Enums.ControlState.Disabled then
+			setIsSelecting(false)
+		end
+	end, {})
+
+	-- TODO: Don't clear the selection when picking again. Allow the user to
+	-- press Esc to deselect or click the selected instance again to deselect.
+
+	useEffect(function()
+		if not isSelecting then
+			return
+		end
+
+		local connection = Selection.SelectionChanged:Connect(function()
+			local selected = Selection:Get()
+			if selected[1] ~= nil then
+				props.onChanged(selected[1])
+				setIsSelecting(false)
+			end
+		end)
+
+		return function()
+			connection:Disconnect()
+		end
+	end, { isSelecting, props.onChanged } :: { unknown })
+
+	local buttonIcon = if currentValue ~= nil
+		then Foundation.Enums.IconName.X
+		else Foundation.Enums.IconName.MouseButtonLeft
+
+	local root: React.ReactElement<any> = e(Foundation.View, {
+		tag = {
+			["size-full-800 row align-y-center gap-small bg-shift-100 radius-medium padding-x-small stroke-position-inner"] = true,
+			["stroke-standard"] = not isActive,
+			["stroke-thick"] = isActive or isSelecting,
+			["stroke-default"] = not isSelecting,
+			["stroke-system-emphasis"] = isSelecting,
+		},
+		onStateChanged = onStateChanged,
+		stateLayer = {
+			affordance = Foundation.Enums.StateLayerAffordance.None,
+		},
+		onActivated = onActivated,
+	}, {
+		ObjectLabel = e(Foundation.Text, {
+			tag = {
+				["auto-xy fill text-body-medium"] = true,
+				["content-muted"] = currentValue == nil,
+				["content-default"] = currentValue ~= nil,
+			},
+			Text = if currentValue then currentValue.Name else PLACEHOLDER,
+		}),
+
+		PrimaryAction = e(Foundation.IconButton, {
+			LayoutOrder = 2,
+			icon = buttonIcon,
+			size = Foundation.Enums.InputSize.Small,
+			onActivated = onActivated,
+		}),
+
+		Backdrop = e(Foundation.Popover.Root, {
+			isOpen = isSelecting,
+		}, {
+			Content = e(Foundation.Popover.Content, {
+				hasArrow = false,
+				onPressedOutside = onBackdropActivated,
+			}),
+		}),
+	})
+
+	if currentValue then
+		root = e(Foundation.Tooltip, {
+			title = currentValue:GetFullName(),
+			side = Foundation.Enums.PopoverSide.Top,
+			align = Foundation.Enums.PopoverAlign.Center,
+		}, root)
+	end
+
+	return root
+end
+
+return React.memo(ObjectControl)

--- a/workspace/flipbook-core/src/StoryControls/ControlElements/ObjectControl.luau
+++ b/workspace/flipbook-core/src/StoryControls/ControlElements/ObjectControl.luau
@@ -71,9 +71,9 @@ local function ObjectControl(props: Props)
 		then Foundation.Enums.IconName.X
 		else Foundation.Enums.IconName.MouseButtonLeft
 
-	local root: React.ReactElement<any> = e(Foundation.View, {
+	return e(Foundation.View, {
 		tag = {
-			["size-full-800 row align-y-center gap-small bg-shift-100 radius-medium padding-x-small flex-between stroke-position-inner"] = true,
+			["size-full-1200 row align-y-center gap-small bg-shift-100 radius-medium padding-x-small flex-between stroke-position-inner"] = true,
 			["stroke-standard"] = not isActive,
 			["stroke-thick"] = isActive or isSelecting,
 			["stroke-default"] = not isSelecting,
@@ -95,7 +95,7 @@ local function ObjectControl(props: Props)
 
 		Selection = if currentValue
 			then e(Foundation.View, {
-				tag = "auto-x size-0-full col",
+				tag = "auto-x size-0-full align-y-center col gap-xsmall",
 			}, {
 				DisplayName = e(Foundation.Text, {
 					tag = "auto-xy content-default text-body-small",
@@ -118,8 +118,6 @@ local function ObjectControl(props: Props)
 			onActivated = onActivated,
 		}),
 	})
-
-	return root
 end
 
 return React.memo(ObjectControl)

--- a/workspace/flipbook-core/src/StoryControls/ControlElements/ObjectControl.luau
+++ b/workspace/flipbook-core/src/StoryControls/ControlElements/ObjectControl.luau
@@ -15,8 +15,6 @@ export type Props = {
 	onChanged: (Instance?) -> (),
 }
 
-local PLACEHOLDER = "Select an Instance"
-
 local function ObjectControl(props: Props)
 	local isSelecting, setIsSelecting = useState(false)
 	local isActive, setIsActive = useState(false)
@@ -89,24 +87,24 @@ local function ObjectControl(props: Props)
 	}, {
 		Placeholder = if not currentValue
 			then e(Foundation.Text, {
-				tag = "auto-x size-0-full content-muted text-body-medium",
+				tag = "auto-x size-0-full content-muted text-body-small",
 				LayoutOrder = 1,
-				Text = if currentValue then currentValue.Name else PLACEHOLDER,
+				Text = "Select an Instance...",
 			})
 			else nil,
 
 		Selection = if currentValue
 			then e(Foundation.View, {
-				tag = "auto-xy col",
+				tag = "auto-x size-0-full col",
 			}, {
 				DisplayName = e(Foundation.Text, {
-					tag = "auto-xy content-default text-body-medium",
+					tag = "auto-xy content-default text-body-small",
 					LayoutOrder = 1,
 					Text = currentValue.Name,
 				}),
 
 				FullName = e(Foundation.Text, {
-					tag = "auto-xy content-muted text-body-small",
+					tag = "auto-xy content-muted text-caption-small",
 					LayoutOrder = 2,
 					Text = currentValue:GetFullName(),
 				}),

--- a/workspace/flipbook-core/src/StoryControls/StoryControlRow.luau
+++ b/workspace/flipbook-core/src/StoryControls/StoryControlRow.luau
@@ -8,6 +8,7 @@ local ColorControl = require("@root/StoryControls/ControlElements/ColorControl")
 local DateControl = require("@root/StoryControls/ControlElements/DateControl")
 local MultiSelectControl = require("@root/StoryControls/ControlElements/MultiSelectControl")
 local NumberControl = require("@root/StoryControls/ControlElements/NumberControl")
+local ObjectControl = require("@root/StoryControls/ControlElements/ObjectControl")
 local RadioControl = require("@root/StoryControls/ControlElements/RadioControl")
 local SelectControl = require("@root/StoryControls/ControlElements/SelectControl")
 local SliderControl = require("@root/StoryControls/ControlElements/SliderControl")
@@ -57,6 +58,12 @@ local function StoryControlRow(props: Props)
 		controlElement = e(NumberControl, {
 			controlSchema = props.control :: Storyteller.NumberControl,
 			controlValue = controlValue :: number,
+			onChanged = setControl,
+		})
+	elseif controlType == ControlType.Object then
+		controlElement = e(ObjectControl, {
+			controlSchema = props.control :: Storyteller.ObjectControl,
+			controlValue = controlValue :: Instance?,
 			onChanged = setControl,
 		})
 	elseif controlType == ControlType.String then

--- a/workspace/flipbook-core/src/StoryControls/StoryControls.story.luau
+++ b/workspace/flipbook-core/src/StoryControls/StoryControls.story.luau
@@ -78,6 +78,7 @@ return {
 
 				color = Storyteller.createColorControl(),
 				date = Storyteller.createDateControl(),
+				object = Storyteller.createObjectControl(),
 			}
 		end, {})
 


### PR DESCRIPTION
# Problem

We want to be able to support using Instances from the DataModel as control values. A similar kind of Instance selection like UI Labs offers, and what the Properties panel natively offers with things like ObjectValues.

# Solution

This PR sets up all the UI necessary for a new Object control type. See video below for a demo. Supports selecting Instances in the DataModel and funneling them through to the story.

Depends on this Storyteller PR that adds the scaffolding for the Object control: https://github.com/flipbook-labs/storyteller/pull/116

https://github.com/user-attachments/assets/fba2a250-2d5d-40e7-9f62-0c465038008d

