### PR TITLE
Make the Rotriever bundle consumable as a path dependency

### DIFF
--- a/.lute/lib/build-system/compileAsync.luau
+++ b/.lute/lib/build-system/compileAsync.luau
@@ -91,11 +91,7 @@ local function compileAsync(context: BuildContext)
 
 		fs.remove(path.join(dest, "src/init.server.luau"))
 
-		local manifestPaths = find(dest, "rotriever.toml")
-		if #manifestPaths > 0 then
-			local manifestPath = manifestPaths[1]
-			fs.copy(manifestPath, path.join(dest, "rotriever.toml"))
-		end
+		fs.copy(path.join(project.WORKSPACE_PATH, "flipbook-core/rotriever.toml"), path.join(dest, "rotriever.toml"))
 
 		-- Bundle up the gigantic dependency bundles into rbxms to alleviate
 		-- path length limit issues that crop up when consuming internally

--- a/workspace/flipbook-core/rotriever.toml
+++ b/workspace/flipbook-core/rotriever.toml
@@ -1,6 +1,6 @@
 [package]
 name = "FlipbookCore"
-content_root = "build"
+content_root = "src"
 version = "2.5.0"
 files = ["*"]
 publish = true


### PR DESCRIPTION
Lifted out of the agents PR (#581) to keep that change focused.

Makes it possible to consume the built `flipbook-core-rotriever` artifact as a path dependency in another `rotriever.toml`:


- Copy the canonical `workspace/flipbook-core/rotriever.toml` directly into the artifact, rather than searching for a stray `rotriever.toml` under the dest. This was resulting in accidentally copying TestEZ's `rotriever.toml`
- Point our `rotriever.toml` to the right path  (`src` instead of `build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)