### PR TITLE
Adopt flipbook-cli's release flow

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -1,0 +1,216 @@
+name: Release Readiness
+
+# Owns the release lifecycle up to the point a maintainer presses "publish" on the
+# drafted GitHub release: build the plugin, decide whether to publish, tag + draft
+# the release, attach the artifact, and open the auto-generated publish PR.
+#
+# The lifecycle itself lives in the `flipbook-cli release` subcommands (gate,
+# draft, attach, prepare-pr). Unlike flipbook-cli's own workflow, which builds its
+# binary from source and runs the subcommands against it, we consume flipbook-cli
+# as a Rokit tool (see rokit.toml) and call it directly.
+#
+# Deployment (publishing the plugin to the Roblox Creator Store) lives separately
+# in release.yml, which fires when the drafted release is published.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      force_publish:
+        description: Tag and create draft release from version on `main`
+        type: boolean
+        default: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: CompeyDev/setup-rokit@v0.1.2
+        with:
+          version: v1.2.0
+
+      - name: Install dependencies
+        run: lute run install
+
+      - name: Create .env
+        run: cp .env.template .env
+
+      - name: Get model file name
+        run: |
+          name=$(jq -r .name default.project.json)
+          echo "MODEL_FILE=$name.rbxm" >> $GITHUB_ENV
+
+      - name: Build
+        run: lute run build plugin --channel prod --output ${{ env.MODEL_FILE }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: asset-rbxm
+          path: ${{ env.MODEL_FILE }}
+
+  gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      has_changes: ${{ steps.eval.outputs.has_changes }}
+      should_publish: ${{ steps.eval.outputs.should_publish }}
+      version: ${{ steps.eval.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: CompeyDev/setup-rokit@v0.1.2
+        with:
+          version: v1.2.0
+
+      - name: Evaluate release action
+        id: eval
+        run: |
+          set -euo pipefail
+          result="$(flipbook-cli release gate ${{ inputs.force_publish && '--force-publish' || '' }})"
+          echo "$result"
+          jq -r 'to_entries[] | "\(.key)=\(.value)"' <<< "$result" >> "$GITHUB_OUTPUT"
+
+  publish-release:
+    needs: gate
+    if: needs.gate.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: CompeyDev/setup-rokit@v0.1.2
+        with:
+          version: v1.2.0
+
+      - name: Tag and draft release
+        run: flipbook-cli release draft --version "${{ needs.gate.outputs.version }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  attach:
+    needs: [build, gate, publish-release]
+    if: needs.gate.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      # Checkout so `gh` can infer the repository from the origin remote.
+      - uses: actions/checkout@v4
+
+      - uses: CompeyDev/setup-rokit@v0.1.2
+        with:
+          version: v1.2.0
+
+      - name: Download release asset
+        uses: actions/download-artifact@v4
+        with:
+          name: asset-rbxm
+          path: assets
+
+      - name: Attach asset to draft release
+        run: flipbook-cli release attach --tag "v${{ needs.gate.outputs.version }}" --files assets/*.rbxm
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  prepare-release-pr:
+    needs: [gate, publish-release]
+    if: |
+      always() &&
+      needs.gate.result == 'success' &&
+      (
+        (needs.gate.outputs.has_changes == 'true' && needs.gate.outputs.should_publish != 'true') ||
+        (needs.gate.outputs.should_publish == 'true' && needs.publish-release.result == 'success')
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-pr-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.FLIPBOOK_BACKEND_APP_ID }}
+          private-key: ${{ secrets.FLIPBOOK_BACKEND_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      # `release prepare-pr` shells out to git-cliff to regenerate the changelog,
+      # which Rokit provides.
+      - uses: CompeyDev/setup-rokit@v0.1.2
+        with:
+          version: v1.2.0
+
+      - name: Prepare release changes
+        id: prepare
+        run: |
+          set -euo pipefail
+          result="$(flipbook-cli release prepare-pr)"
+          echo "$result"
+          jq -r 'to_entries[] | "\(.key)=\(.value)"' <<< "$result" >> "$GITHUB_OUTPUT"
+
+      - name: Sync version across Flipbook's other manifests
+        run: |
+          # flipbook-cli's `release prepare-pr` only bumps loom.config.luau, but
+          # Flipbook publishes a Wally package (FlipbookCore) and a rotriever
+          # package whose versions must stay in lockstep (see .lute/bump-version,
+          # which bumps all three). Both manifests carry the package version as
+          # their sole top-level `version = "..."` line, so propagate the bumped
+          # version here.
+          # TODO(flipbook-cli): teach `release prepare-pr` about extra manifests so
+          # this sync step can go away once Flipbook's use case is supported natively.
+          version="${{ steps.prepare.outputs.version }}"
+          sed -i "s/^version = \".*\"/version = \"$version\"/" \
+            wally.toml workspace/flipbook-core/rotriever.toml
+
+      - name: Create or update publish PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          # Push as the GitHub App rather than the default GITHUB_TOKEN so the
+          # branch push triggers CI on the publish PR. Pushes made with
+          # GITHUB_TOKEN do not trigger further workflow runs.
+          # Read more: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+          token: ${{ steps.app-token.outputs.token }}
+          base: ${{ github.ref_name }}
+          branch: publish-next-version
+          commit-message: Publish v${{ steps.prepare.outputs.version }}
+          title: "[AUTO-GENERATED] Publish v${{ steps.prepare.outputs.version }}"
+          add-paths: |
+            CHANGELOG.md
+            loom.config.luau
+            wally.toml
+            workspace/flipbook-core/rotriever.toml
+          body: |
+            >[!IMPORTANT]
+            > This PR prepares the next release by bumping the version and updating the changelog.
+            >
+            > **Merging this PR will:**
+            >
+            > 1. Create and push tag `v${{ steps.prepare.outputs.version }}`
+            > 2. Create a draft GitHub release for that tag
+            > 3. Build and attach the `Flipbook.rbxm` plugin to the draft release
+            >
+            > Publishing the draft release then deploys the plugin to the Roblox Creator Store.
+
+            Next release will be available here:
+            ${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ steps.prepare.outputs.version }}
+
+            🤖 This PR was generated by [this run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -96,6 +96,10 @@ jobs:
         run: flipbook-cli release draft --version "${{ needs.gate.outputs.version }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # `release draft` shells out to git-cliff for the release notes; the
+          # token enables git-cliff's GitHub integration so commits are grouped by
+          # their PR labels (see cliff.toml).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   attach:
     needs: [build, gate, publish-release]
@@ -166,6 +170,11 @@ jobs:
           result="$(flipbook-cli release prepare-pr)"
           echo "$result"
           jq -r 'to_entries[] | "\(.key)=\(.value)"' <<< "$result" >> "$GITHUB_OUTPUT"
+        env:
+          # `release prepare-pr` regenerates the changelog via git-cliff; the token
+          # enables git-cliff's GitHub integration so commits are grouped by their
+          # PR labels (see cliff.toml).
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Sync version across Flipbook's other manifests
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,10 @@
 name: Release
 
+# Owns deployment: publishing the plugin to the Roblox Creator Store. Prod is
+# published when a maintainer publishes the GitHub release that Release Readiness
+# (release-readiness.yml) drafted; nightly dev builds publish on every push to
+# main.
+
 on:
   release:
     types: [published]
@@ -9,38 +14,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  publish-github-release:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    if: ${{ github.event.release }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: CompeyDev/setup-rokit@v0.1.2
-        with:
-          version: v1.2.0
-
-      - name: Get model file name
-        run: |
-          name=$(jq -r .name default.project.json)
-          echo "MODEL_FILE=$name.rbxm" >> $GITHUB_ENV
-
-      - name: Install dependencies
-        run: lute run install
-
-      - name: Create .env
-        run: cp .env.template .env
-
-      - name: Build
-        run: lute run build --channel prod --output ${{ env.MODEL_FILE }}
-
-      - uses: softprops/action-gh-release@v1
-        with:
-          files: ${{ env.MODEL_FILE }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   publish-plugin:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/cliff.toml
+++ b/cliff.toml
@@ -10,10 +10,6 @@ All notable changes to this project will be documented in this file.
 """
 
 body = """
-{% macro remote_url() -%}
-https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
-{%- endmacro %}
-
 {% if version -%}
 ## {{ version }}
 {% else -%}
@@ -23,10 +19,15 @@ https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | striptags | trim | upper_first }}
 {% for commit in commits %}
-- {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}]({{ self::remote_url() }}/commit/{{ commit.id }}))
+- {{ commit.message | upper_first }}
 {% endfor %}
 {% endfor %}
 """
+
+# Turn `(#123)` PR references in the rendered changelog into links to the PR.
+postprocessors = [
+  { pattern = '\(#(\d+)\)', replace = "([#${1}](https://github.com/flipbook-labs/flipbook/pull/${1}))" },
+]
 
 trim = true
 
@@ -47,10 +48,32 @@ commit_preprocessors = [
   { pattern = '(?s)\s+$', replace = "" },
 ]
 
+# Commits are grouped by the labels on their squash-merged PR, surfaced by
+# git-cliff's GitHub integration (see [remote.github] above). The integration is
+# active whenever a GITHUB_TOKEN is in the environment; the workflow passes one
+# into the git-cliff steps. Without a token, `github.pr_labels` is empty and every
+# commit falls through to the catch-all "Changes" group (PR links still work,
+# since those come from the postprocessor, not the integration).
+#
+# The first matching parser wins, so message-based skips/routes come before the
+# label rules, and the catch-all comes last. Group order in the changelog is set
+# by the `<!-- N -->` prefix, which the body strips via `striptags`.
 commit_parsers = [
   # Skip the auto-generated publish commits. Their squash-merge subject is the
   # PR title (e.g. "[AUTO-GENERATED] Publish v2.6.0 (#27)"), so match "Publish v"
   # anywhere rather than anchoring to the start of the message.
   { message = "Publish v[0-9]", skip = true },
-  { message = ".*", group = "Changes" },
+  # Skip the historical manual version-bump commits (e.g. "Bump version to 2.5.0"),
+  # the pre-automation equivalent of the publish commits above.
+  { message = "^Bump version to", skip = true },
+  # Automated dependency upgrades are unlabeled, so route them by message.
+  { message = "Upgrade RobloxPackages", group = "<!-- 4 -->Dependencies" },
+  # Label-based grouping. Add a label to a PR to file it under one of these.
+  { field = "github.pr_labels", pattern = "enhancement", group = "<!-- 0 -->Features" },
+  { field = "github.pr_labels", pattern = "bug", group = "<!-- 1 -->Bug Fixes" },
+  { field = "github.pr_labels", pattern = "documentation", group = "<!-- 2 -->Documentation" },
+  { field = "github.pr_labels", pattern = "accessibility", group = "<!-- 3 -->Accessibility" },
+  { field = "github.pr_labels", pattern = "nonprod", group = "<!-- 5 -->Internal" },
+  # Anything without a recognized label lands here.
+  { message = ".*", group = "<!-- 6 -->Changes" },
 ]

--- a/cliff.toml
+++ b/cliff.toml
@@ -63,11 +63,12 @@ commit_parsers = [
   # PR title (e.g. "[AUTO-GENERATED] Publish v2.6.0 (#27)"), so match "Publish v"
   # anywhere rather than anchoring to the start of the message.
   { message = "Publish v[0-9]", skip = true },
-  # Skip the historical manual version-bump commits (e.g. "Bump version to 2.5.0"),
-  # the pre-automation equivalent of the publish commits above.
-  { message = "^Bump version to", skip = true },
-  # Automated dependency upgrades are unlabeled, so route them by message.
+  # Version/dependency housekeeping shares the "Dependencies" section: the
+  # automated RobloxPackages upgrades and the historical manual version bumps
+  # (e.g. "Bump version to 2.5.0", the pre-automation release mechanism). These
+  # are unlabeled, so route them by message.
   { message = "Upgrade RobloxPackages", group = "<!-- 4 -->Dependencies" },
+  { message = "^Bump version to", group = "<!-- 4 -->Dependencies" },
   # Label-based grouping. Add a label to a PR to file it under one of these.
   { field = "github.pr_labels", pattern = "enhancement", group = "<!-- 0 -->Features" },
   { field = "github.pr_labels", pattern = "bug", group = "<!-- 1 -->Bug Fixes" },

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,56 @@
+[remote.github]
+owner = "flipbook-labs"
+repo = "flipbook"
+
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+"""
+
+body = """
+{% macro remote_url() -%}
+https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
+{%- endmacro %}
+
+{% if version -%}
+## {{ version }}
+{% else -%}
+## Unreleased
+{% endif -%}
+
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}]({{ self::remote_url() }}/commit/{{ commit.id }}))
+{% endfor %}
+{% endfor %}
+"""
+
+trim = true
+
+[bump]
+initial_tag = "v0.1.0"
+
+[git]
+conventional_commits = false
+filter_unconventional = false
+split_commits = false
+tag_pattern = "v[0-9].*"
+sort_commits = "newest"
+
+commit_preprocessors = [
+  { pattern = '(?s)\nCo-authored-by:.*$', replace = "" },
+  { pattern = '(?s)\nMade-with:.*$', replace = "" },
+  { pattern = '(?s)\n\n.*$', replace = "" },
+  { pattern = '(?s)\s+$', replace = "" },
+]
+
+commit_parsers = [
+  # Skip the auto-generated publish commits. Their squash-merge subject is the
+  # PR title (e.g. "[AUTO-GENERATED] Publish v2.6.0 (#27)"), so match "Publish v"
+  # anywhere rather than anchoring to the start of the message.
+  { message = "Publish v[0-9]", skip = true },
+  { message = ".*", group = "Changes" },
+]

--- a/rokit.toml
+++ b/rokit.toml
@@ -5,6 +5,8 @@
 
 [tools]
 darklua = "seaofvoices/darklua@0.17.1"
+flipbook-cli = "flipbook-labs/flipbook-cli@0.5.0"
+git-cliff = "orhun/git-cliff@2.13.1"
 luau-lsp = "JohnnyMorganz/luau-lsp@1.60.1"
 lune = "lune-org/lune@0.9.4"
 lute = "luau-lang/lute@1.0.0"


### PR DESCRIPTION
# Problem

Flipbook releases are manual: a maintainer runs `.lute/bump-version`, opens a PR by hand, and tags. Meanwhile `flipbook-cli` has grown a first-class release lifecycle (`flipbook-cli release gate | draft | attach | prepare-pr`, shipped in `v0.5.0`) plus a GitHub Actions workflow that automates the whole loop. We want Flipbook on that same flow.

# Solution

Consume `flipbook-cli` as a Rokit tool and wire its subcommands into CI, modeled on flipbook-cli's own release workflow. The automation is split at the point a maintainer presses "publish":

- **`release-readiness.yml`** (new) owns the readiness lifecycle. On every push to `main` it builds the plugin, runs `flipbook-cli release gate` to decide whether to publish, tags + drafts the GitHub release (`release draft`), attaches `Flipbook.rbxm` (`release attach`), and opens an auto-generated `[AUTO-GENERATED] Publish vX.Y.Z` PR (`release prepare-pr` + `peter-evans/create-pull-request`) that bumps the version and regenerates the changelog. Merging that PR releases the version and prepares the next.
- **`release.yml`** is trimmed to deployment only — publishing the plugin to the Roblox Creator Store (prod on `release: published`, nightly dev on push to `main`). The old `publish-github-release` job is gone; building/attaching the `.rbxm` now lives in Release Readiness.
- **`cliff.toml`** (new) configures changelog generation, mirroring flipbook-cli's config with the repo set to `flipbook-labs/flipbook`.

### Flipbook-specific considerations

- **flipbook-cli builds binaries; we don't.** We consume `flipbook-cli` from Rokit (`rokit.toml`) and call it directly rather than building a binary from source, and we attach the prod `Flipbook.rbxm` plugin model instead of per-platform binaries.
- **Three manifests, one version.** `flipbook-cli release prepare-pr` only bumps `loom.config.luau`, but Flipbook keeps `wally.toml` and `workspace/flipbook-core/rotriever.toml` in lockstep. A commented sync step propagates the bumped version into those two, with a `TODO(flipbook-cli)` to carve out native support later.

### Before this can run

> [!IMPORTANT]
> The `flipbook-cli@0.5.0` release is currently a **draft** on `flipbook-labs/flipbook-cli`, so Rokit can't install it yet. The flipbook-cli v0.5.0 draft release needs to be published first.

- Requires the `FLIPBOOK_BACKEND_APP_ID` / `FLIPBOOK_BACKEND_APP_PRIVATE_KEY` secrets (same org secrets flipbook-cli uses) to be available to this repo.
- First run on current `main`: gate sees `v2.5.0` is tagged with commits on top → opens the first publish PR bumping `2.5.0 → 2.6.0` and generating `CHANGELOG.md`. No accidental publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)