### PR TITLE
Update darklua to 0.19.0 and declare content loaders

### DIFF
--- a/.darklua.json
+++ b/.darklua.json
@@ -52,5 +52,12 @@
     "filter_after_early_return",
     "remove_nil_declaration",
     "remove_empty_do"
-  ]
+  ],
+  "loaders": {
+    "**/*.model.json": "copy",
+    "**/*.project.json": "copy",
+    "**/*.json": "copy",
+    "**/*.toml": "copy",
+    "**/*.md": "copy"
+  }
 }

--- a/rokit.toml
+++ b/rokit.toml
@@ -4,7 +4,7 @@
 # New tools can be added by running `rokit add <tool>` in a terminal.
 
 [tools]
-darklua = "seaofvoices/darklua@0.17.1"
+darklua = "seaofvoices/darklua@0.19.0"
 luau-lsp = "JohnnyMorganz/luau-lsp@1.60.1"
 lune = "lune-org/lune@0.9.4"
 lute = "luau-lang/lute@1.0.0"


### PR DESCRIPTION
# Problem

darklua is pinned at `0.17.1`. Version `0.19.0` introduces **content loaders** and, as part of that, **changes the default handling of non-luau files** inside a `darklua process` directory:

| File in a processed dir | 0.17.1 (current) | 0.19.0 **default** |
|---|---|---|
| `*.json` (incl. `*.model.json`, `*.project.json`) | left untouched | **inlined as Lua, renamed `.lua`** |
| `*.toml` | left untouched | inlined as Lua → `.lua` |
| `*.md` | left untouched | **dropped** |

For a Rojo project that's a footgun: a `.model.json` or `.project.json` that lands in a processed source tree would be silently rewritten into a Lua return table instead of staying valid Rojo JSON. (Today nothing breaks — every directory we actually process contains only `.luau` files — but the new default is a latent trap.)

# Solution

- Bump `darklua` to `0.19.0` in `rokit.toml`.
- Declare an explicit top-level `loaders` block in `.darklua.json` mapping Rojo/data/doc globs (`*.model.json`, `*.project.json`, `*.json`, `*.toml`, `*.md`) to the `copy` loader, so non-luau files pass through `darklua process` verbatim under the new defaults. Luau files keep the default `luau` loader.

This maps the build onto 0.19.0's loader behavior and keeps output deterministic regardless of which file types land in a processed tree.

Verified the 0.19.0 default vs. `copy`-loader behavior empirically against both binaries on a fixture, and confirmed the current build's processed trees are luau-only (so output is unchanged).

> Note: a follow-up is being investigated separately — trimming the install-time string-require patch list in `.lute/install.luau` (`luaulog` ships no requires; testing whether charm/react-charm still need patching under the new runtime). Kept out of this PR since it's verification-gated and independent of the version bump.