### PR TITLE
Fix the dev build failing to deploy

### DIFF
--- a/.lune/publish-plugin.luau
+++ b/.lune/publish-plugin.luau
@@ -20,7 +20,16 @@ assert(typeof(apiKey) == "string", `bad value for apiKey (string expected, got {
 
 run("lute", { "run", "build", "plugin", "--channel", channel, "--output", "Flipbook.rbxm" })
 
-local assetName = if args.smoketest then "smoketest" else channel
+type ChannelName = "dev" | "beta" | "prod"
+type AssetName = "dev" | "prod" | "smoketest"
+
+local ASSET_NAMES_BY_CHANNEL: { [ChannelName]: AssetName } = {
+	dev = "dev",
+	beta = "dev",
+	prod = "prod",
+}
+
+local assetName: AssetName = if args.smoketest then "smoketest" else ASSET_NAMES_BY_CHANNEL[channel]
 
 -- Each of the assets defined in rbxasset.toml map to one of the options of
 -- `--channel` for simplicity

--- a/.lune/publish-plugin.luau
+++ b/.lune/publish-plugin.luau
@@ -31,6 +31,6 @@ local ASSET_NAMES_BY_CHANNEL: { [ChannelName]: AssetName } = {
 
 local assetName: AssetName = if args.smoketest then "smoketest" else ASSET_NAMES_BY_CHANNEL[channel]
 
--- Each of the assets defined in rbxasset.toml map to one of the options of
--- `--channel` for simplicity
+-- Each of the assets defined in rbxasset.toml corresponds to a deploy target.
+-- Multiple channels can share the same asset (e.g. beta reuses dev).
 rbxasset.publishPackageAsync(process.cwd, assetName, apiKey)


### PR DESCRIPTION
## Problem

I broke the dev build in https://github.com/flipbook-labs/flipbook/pull/583 when introducing the new "beta" channel. @greptileai actually surfaced the issue but I forgot to handle it before merging

## Solution

To address this, we're now properly mapping the `--channel` option to the right asset name in `rbxasset.toml`. 

Previously we funneled the channel right on through as the name to use for the asset, but there isn't a "beta" asset defined in the manifest. And there still isn't, but now we route beta -> dev

## Testing

 Gotta test by merging and verifying that the deployment works

## Notes for reviewers

<!-- (Optional) Anything to call out? Tradeoffs, risky areas, follow-ups, things you're unsure about -->
