### PR TITLE
Extract InstancePicker component from ObjectControl

### DIFF
--- a/workspace/flipbook-core/src/Common/ContextProviders.luau
+++ b/workspace/flipbook-core/src/Common/ContextProviders.luau
@@ -11,13 +11,13 @@ local useEffect = React.useEffect
 
 export type Props = {
 	plugin: Plugin,
-	theme: ("Dark" | "Light")?,
+	theme: Foundation.Theme?,
 	overlayGui: GuiBase2d?,
 	children: React.Node?,
 }
 
 local function ContextProviders(props: Props)
-	local themeName: "Dark" | "Light" = useThemeName()
+	local themeName: Foundation.Theme = useThemeName()
 
 	useEffect(function()
 		PluginStore.get().setPlugin(props.plugin)

--- a/workspace/flipbook-core/src/Common/ContextProviders.luau
+++ b/workspace/flipbook-core/src/Common/ContextProviders.luau
@@ -11,6 +11,7 @@ local useEffect = React.useEffect
 
 export type Props = {
 	plugin: Plugin,
+	theme: ("Dark" | "Light")?,
 	overlayGui: GuiBase2d?,
 	children: React.Node?,
 }
@@ -25,7 +26,7 @@ local function ContextProviders(props: Props)
 	return React.createElement(ContextStack, {
 		providers = {
 			React.createElement(Foundation.FoundationProvider, {
-				theme = themeName,
+				theme = props.theme or themeName,
 				overlayGui = props.overlayGui,
 			}),
 			React.createElement(NavigationContext.Provider, {

--- a/workspace/flipbook-core/src/Common/InstancePicker.luau
+++ b/workspace/flipbook-core/src/Common/InstancePicker.luau
@@ -1,0 +1,115 @@
+local Selection = game:GetService("Selection")
+
+local Foundation = require("@rbxpkg/Foundation")
+local React = require("@pkg/React")
+
+local e = React.createElement
+local useCallback = React.useCallback
+local useEffect = React.useEffect
+local useState = React.useState
+
+export type Props = {
+	value: Instance?,
+	onChanged: (Instance?) -> (),
+}
+
+local function InstancePicker(props: Props)
+	local isSelecting, setIsSelecting = useState(false)
+	local isActive, setIsActive = useState(false)
+
+	local onActivated = useCallback(function()
+		if isSelecting then
+			setIsActive(false)
+			setIsSelecting(false)
+		else
+			setIsSelecting(true)
+		end
+	end, { isSelecting } :: { unknown })
+
+	local onClear = useCallback(function()
+		setIsActive(false)
+		setIsSelecting(false)
+		props.onChanged(nil)
+	end, { props.onChanged } :: { unknown })
+
+	local onStateChanged = useCallback(function(newState: Foundation.ControlState)
+		setIsActive(
+			newState == Foundation.Enums.ControlState.Hover or newState == Foundation.Enums.ControlState.Pressed
+		)
+		if newState == Foundation.Enums.ControlState.Disabled then
+			setIsSelecting(false)
+		end
+	end, {})
+
+	useEffect(function()
+		if not isSelecting then
+			return
+		end
+
+		local connection = Selection.SelectionChanged:Connect(function()
+			local selected = Selection:Get()
+			if selected[1] ~= nil then
+				props.onChanged(selected[1])
+				setIsSelecting(false)
+			end
+		end)
+
+		return function()
+			connection:Disconnect()
+		end
+	end, { isSelecting, props.onChanged } :: { unknown })
+
+	local buttonIcon = if props.value ~= nil
+		then Foundation.Enums.IconName.X
+		else Foundation.Enums.IconName.MouseButtonLeft
+
+	return e(Foundation.View, {
+		tag = {
+			["size-full-1200 row align-y-center gap-small bg-shift-100 radius-medium padding-x-small flex-between stroke-position-inner"] = true,
+			["stroke-standard"] = not isActive,
+			["stroke-thick"] = isActive or isSelecting,
+			["stroke-default"] = not isSelecting,
+			["stroke-system-emphasis"] = isSelecting,
+		},
+		onStateChanged = onStateChanged,
+		stateLayer = {
+			affordance = Foundation.Enums.StateLayerAffordance.None,
+		},
+		onActivated = onActivated,
+	}, {
+		Placeholder = if not props.value
+			then e(Foundation.Text, {
+				tag = "auto-x size-0-full content-muted text-body-small",
+				LayoutOrder = 1,
+				Text = "Select an Instance...",
+			})
+			else nil,
+
+		Selection = if props.value
+			then e(Foundation.View, {
+				tag = "auto-x size-0-full align-y-center col gap-xsmall",
+			}, {
+				DisplayName = e(Foundation.Text, {
+					tag = "auto-xy content-default text-body-small",
+					LayoutOrder = 1,
+					Text = props.value.Name,
+				}),
+
+				FullName = e(Foundation.Text, {
+					tag = "auto-xy content-muted text-caption-small",
+					LayoutOrder = 2,
+					Text = props.value:GetFullName(),
+				}),
+			})
+			else nil,
+
+		PrimaryAction = e(Foundation.IconButton, {
+			LayoutOrder = 2,
+			icon = buttonIcon,
+			size = Foundation.Enums.InputSize.XSmall,
+			onActivated = if props.value ~= nil then onClear else onActivated,
+		}),
+	})
+end
+
+return React.memo(InstancePicker)

--- a/workspace/flipbook-core/src/Common/InstancePicker.luau
+++ b/workspace/flipbook-core/src/Common/InstancePicker.luau
@@ -11,6 +11,7 @@ local useState = React.useState
 export type Props = {
 	value: Instance?,
 	onChanged: (Instance?) -> (),
+	LayoutOrder: number?,
 }
 
 local function InstancePicker(props: Props)
@@ -76,6 +77,7 @@ local function InstancePicker(props: Props)
 			affordance = Foundation.Enums.StateLayerAffordance.None,
 		},
 		onActivated = onActivated,
+		LayoutOrder = props.LayoutOrder,
 	}, {
 		Placeholder = if not props.value
 			then e(Foundation.Text, {

--- a/workspace/flipbook-core/src/Common/InstancePicker.story.luau
+++ b/workspace/flipbook-core/src/Common/InstancePicker.story.luau
@@ -11,7 +11,7 @@ return {
 		local value, setValue = useState(nil :: Instance?)
 
 		return React.createElement(Foundation.View, {
-			tag = "size-full-0 auto-y",
+			tag = "size-full-0 auto-y col gap-large",
 			sizeConstraint = {
 				MaxSize = Vector2.new(300, math.huge),
 			},
@@ -19,6 +19,10 @@ return {
 			InstancePicker = React.createElement(InstancePicker, {
 				value = value,
 				onChanged = setValue,
+			}),
+
+			WithSelectedInstance = React.createElement(InstancePicker, {
+				value = workspace,
 			}),
 		})
 	end,

--- a/workspace/flipbook-core/src/Common/InstancePicker.story.luau
+++ b/workspace/flipbook-core/src/Common/InstancePicker.story.luau
@@ -1,0 +1,25 @@
+local Foundation = require("@rbxpkg/Foundation")
+local React = require("@pkg/React")
+
+local InstancePicker = require("./InstancePicker")
+
+local useState = React.useState
+
+return {
+	summary = "Lets users pick an Instance from the current Selection",
+	story = function()
+		local value, setValue = useState(nil :: Instance?)
+
+		return React.createElement(Foundation.View, {
+			tag = "size-full-0 auto-y",
+			sizeConstraint = {
+				MaxSize = Vector2.new(300, math.huge),
+			},
+		}, {
+			InstancePicker = React.createElement(InstancePicker, {
+				value = value,
+				onChanged = setValue,
+			}),
+		})
+	end,
+}

--- a/workspace/flipbook-core/src/Common/InstancePicker.story.luau
+++ b/workspace/flipbook-core/src/Common/InstancePicker.story.luau
@@ -19,10 +19,13 @@ return {
 			InstancePicker = React.createElement(InstancePicker, {
 				value = value,
 				onChanged = setValue,
+				LayoutOrder = 1,
 			}),
 
 			WithSelectedInstance = React.createElement(InstancePicker, {
 				value = workspace,
+				onChanged = function() end,
+				LayoutOrder = 2,
 			}),
 		})
 	end,

--- a/workspace/flipbook-core/src/StoryControls/ControlElements/ObjectControl.luau
+++ b/workspace/flipbook-core/src/StoryControls/ControlElements/ObjectControl.luau
@@ -6,7 +6,7 @@ local InstancePicker = require("@root/Common/InstancePicker")
 local e = React.createElement
 
 export type Props = {
-	controlSchema: Storyteller.ObjectControl?,
+	controlSchema: Storyteller.ObjectControl,
 	controlValue: Instance?,
 	onChanged: (Instance?) -> (),
 }

--- a/workspace/flipbook-core/src/StoryControls/ControlElements/ObjectControl.luau
+++ b/workspace/flipbook-core/src/StoryControls/ControlElements/ObjectControl.luau
@@ -1,118 +1,22 @@
-local Selection = game:GetService("Selection")
-
-local Foundation = require("@rbxpkg/Foundation")
 local React = require("@pkg/React")
 local Storyteller = require("@pkg/Storyteller")
 
+local InstancePicker = require("@root/Common/InstancePicker")
+
 local e = React.createElement
-local useCallback = React.useCallback
-local useEffect = React.useEffect
-local useState = React.useState
 
 export type Props = {
-	controlSchema: Storyteller.ObjectControl,
+	controlSchema: Storyteller.ObjectControl?,
 	controlValue: Instance?,
 	onChanged: (Instance?) -> (),
 }
 
 local function ObjectControl(props: Props)
-	local isSelecting, setIsSelecting = useState(false)
-	local isActive, setIsActive = useState(false)
+	local currentValue = props.controlValue or (props.controlSchema and props.controlSchema.default)
 
-	local currentValue = props.controlValue or props.controlSchema.default
-
-	local onActivated = useCallback(function()
-		if isSelecting then
-			setIsActive(false)
-			setIsSelecting(false)
-		else
-			setIsSelecting(true)
-		end
-	end, { isSelecting } :: { unknown })
-
-	local onClear = useCallback(function()
-		setIsActive(false)
-		setIsSelecting(false)
-		props.onChanged(nil)
-	end, { props.onChanged } :: { unknown })
-
-	local onStateChanged = useCallback(function(newState: Foundation.ControlState)
-		setIsActive(
-			newState == Foundation.Enums.ControlState.Hover or newState == Foundation.Enums.ControlState.Pressed
-		)
-		if newState == Foundation.Enums.ControlState.Disabled then
-			setIsSelecting(false)
-		end
-	end, {})
-
-	useEffect(function()
-		if not isSelecting then
-			return
-		end
-
-		local connection = Selection.SelectionChanged:Connect(function()
-			local selected = Selection:Get()
-			if selected[1] ~= nil then
-				props.onChanged(selected[1])
-				setIsSelecting(false)
-			end
-		end)
-
-		return function()
-			connection:Disconnect()
-		end
-	end, { isSelecting, props.onChanged } :: { unknown })
-
-	local buttonIcon = if currentValue ~= nil
-		then Foundation.Enums.IconName.X
-		else Foundation.Enums.IconName.MouseButtonLeft
-
-	return e(Foundation.View, {
-		tag = {
-			["size-full-1200 row align-y-center gap-small bg-shift-100 radius-medium padding-x-small flex-between stroke-position-inner"] = true,
-			["stroke-standard"] = not isActive,
-			["stroke-thick"] = isActive or isSelecting,
-			["stroke-default"] = not isSelecting,
-			["stroke-system-emphasis"] = isSelecting,
-		},
-		onStateChanged = onStateChanged,
-		stateLayer = {
-			affordance = Foundation.Enums.StateLayerAffordance.None,
-		},
-		onActivated = onActivated,
-	}, {
-		Placeholder = if not currentValue
-			then e(Foundation.Text, {
-				tag = "auto-x size-0-full content-muted text-body-small",
-				LayoutOrder = 1,
-				Text = "Select an Instance...",
-			})
-			else nil,
-
-		Selection = if currentValue
-			then e(Foundation.View, {
-				tag = "auto-x size-0-full align-y-center col gap-xsmall",
-			}, {
-				DisplayName = e(Foundation.Text, {
-					tag = "auto-xy content-default text-body-small",
-					LayoutOrder = 1,
-					Text = currentValue.Name,
-				}),
-
-				FullName = e(Foundation.Text, {
-					tag = "auto-xy content-muted text-caption-small",
-					LayoutOrder = 2,
-					Text = currentValue:GetFullName(),
-				}),
-			})
-			else nil,
-
-		PrimaryAction = e(Foundation.IconButton, {
-			LayoutOrder = 2,
-			icon = buttonIcon,
-			size = Foundation.Enums.InputSize.XSmall,
-			onActivated = if currentValue ~= nil then onClear else onActivated,
-		}),
+	return e(InstancePicker, {
+		value = currentValue,
+		onChanged = props.onChanged,
 	})
 end
 

--- a/workspace/flipbook-core/src/init.storybook.luau
+++ b/workspace/flipbook-core/src/init.storybook.luau
@@ -17,6 +17,7 @@ return {
 		return function(props)
 			return React.createElement(ContextProviders, {
 				plugin = MockPlugin.new(),
+				theme = props.theme,
 				overlayGui = props.container,
 			}, {
 				Story = React.createElement(Story, props),


### PR DESCRIPTION
## Problem

<!-- Why are we making this change? Link the issue if there is one. -->

We need to extend our ObjectControl to a more generalized component for the Storybook Embedding work so we can prompt the user in a Dialog to select an instance to embed into. ObjectControl is specific to the controls panel so we want to reuse the underlying logic while having independent styling for both cases

## Solution

Created a new InstancePicker component that hoists out the internals of ObjectControl. Here's how it looks:

<img width="421" height="233" alt="Screenshot 2026-06-16 at 8 22 28 PM" src="https://github.com/user-attachments/assets/f3cb505e-ff4f-4e4d-b2f4-f0d709ae6f43" />

<img width="400" height="245" alt="Screenshot 2026-06-16 at 8 36 46 PM" src="https://github.com/user-attachments/assets/f84b2840-ca91-47fe-b7d2-35448437f0fa" />


Split from https://github.com/flipbook-labs/flipbook/pull/582

## Testing

<!-- How did you verify this works? Unit testing preferred, manual verification also common -->

## Notes for reviewers

<!-- (Optional) Anything to call out? Tradeoffs, risky areas, follow-ups, things you're unsure about -->
