### PR TITLE
Show multi-story modules in the sidebar

### DIFF
--- a/workspace/flipbook-core/src/FlipbookApp.luau
+++ b/workspace/flipbook-core/src/FlipbookApp.luau
@@ -36,32 +36,38 @@ local function FlipbookApp(props: Props)
 	local userSettings = useSignalState(userSettingsStore.getStorage)
 
 	local storyModule: ModuleScript?, setStoryModule = React.useState(nil :: ModuleScript?)
+	local storyId: string?, setStoryId = React.useState(nil :: string?)
 	local storybook, setStorybook = React.useState(nil :: LoadedStorybook?)
 	local unavailableStorybook: UnavailableStorybook?, setUnavailableStorybook =
 		React.useState(nil :: UnavailableStorybook?)
 	local navigation = NavigationContext.use()
 
-	local onStoryChanged = React.useCallback(function(newStoryModule: ModuleScript?, newStorybook: LoadedStorybook?)
-		navigation.navigateTo("Home")
+	local onStoryChanged = React.useCallback(
+		function(newStoryModule: ModuleScript?, newStorybook: LoadedStorybook?, newStoryId: string?)
+			navigation.navigateTo("Home")
 
-		setUnavailableStorybook(nil)
+			setUnavailableStorybook(nil)
 
-		if newStoryModule and not newStorybook then
-			newStorybook = defaultStorybook
-		end
+			if newStoryModule and not newStorybook then
+				newStorybook = defaultStorybook
+			end
 
-		task.spawn(function()
-			fireEventAsync({
-				eventName = "StoryOpened",
-			})
-		end)
+			task.spawn(function()
+				fireEventAsync({
+					eventName = "StoryOpened",
+				})
+			end)
 
-		setStoryModule(newStoryModule)
-		setStorybook(newStorybook)
-	end, { navigation.navigateTo } :: { unknown })
+			setStoryModule(newStoryModule)
+			setStoryId(newStoryId)
+			setStorybook(newStorybook)
+		end,
+		{ navigation.navigateTo } :: { unknown }
+	)
 
 	local onShowErrorPage = React.useCallback(function(newUnavailableStorybook: UnavailableStorybook)
 		setStoryModule(nil)
+		setStoryId(nil)
 		setStorybook(nil)
 		setUnavailableStorybook(newUnavailableStorybook)
 	end, {})
@@ -103,6 +109,7 @@ local function FlipbookApp(props: Props)
 				}, {
 					Screen = React.createElement(Screen, {
 						story = storyModule,
+						storyId = storyId,
 						storybook = storybook,
 						unavailableStorybook = unavailableStorybook,
 					}),

--- a/workspace/flipbook-core/src/Navigation/Screen.luau
+++ b/workspace/flipbook-core/src/Navigation/Screen.luau
@@ -16,6 +16,7 @@ type UnavailableStorybook = Storyteller.UnavailableStorybook
 
 export type Props = {
 	story: ModuleScript?,
+	storyId: string?,
 	storybook: LoadedStorybook?,
 	unavailableStorybook: UnavailableStorybook?,
 }
@@ -28,6 +29,7 @@ local function Screen(props: Props)
 		if currentScreen == "Home" then
 			if props.story and props.storybook then
 				return React.createElement(StoryView, {
+					storyId = props.storyId,
 					storyModule = props.story,
 					storybook = props.storybook,
 				})

--- a/workspace/flipbook-core/src/Panels/Sidebar.luau
+++ b/workspace/flipbook-core/src/Panels/Sidebar.luau
@@ -18,7 +18,7 @@ type LoadedStorybook = Storyteller.LoadedStorybook
 type UnavailableStorybook = Storyteller.UnavailableStorybook
 
 type SidebarProps = {
-	onStoryChanged: (storyModule: ModuleScript?, storybook: LoadedStorybook?) -> (),
+	onStoryChanged: (storyModule: ModuleScript?, storybook: LoadedStorybook?, storyId: string?) -> (),
 	onShowErrorPage: (unavailableStorybook: UnavailableStorybook) -> (),
 } & Foundation.CommonProps
 

--- a/workspace/flipbook-core/src/Plugin/LocalStorageStore.luau
+++ b/workspace/flipbook-core/src/Plugin/LocalStorageStore.luau
@@ -4,6 +4,7 @@ local t = require("@pkg/t")
 local createPluginSettingsStore = require("@root/Plugin/createPluginSettingsStore")
 
 export type LocalStorageStore = {
+	lastOpenedStoryId: string?,
 	lastOpenedStoryPath: string?,
 	pinnedInstancePaths: { string }?,
 	wasUserPromptedForTelemetry: boolean,
@@ -14,6 +15,7 @@ local defaultValue: LocalStorageStore = {
 }
 
 local validate = t.interface({
+	lastOpenedStoryId = t.optional(t.string),
 	lastOpenedStoryPath = t.optional(t.string),
 	pinnedInstancePaths = t.optional(t.array(t.string)),
 	wasUserPromptedForTelemetry = t.boolean,

--- a/workspace/flipbook-core/src/Storybook/MultipleStories.story.luau
+++ b/workspace/flipbook-core/src/Storybook/MultipleStories.story.luau
@@ -1,0 +1,42 @@
+local React = require("@pkg/React")
+
+local controls = {
+	label = "Multiple stories work",
+}
+
+type Props = {
+	controls: typeof(controls),
+}
+
+local function createStory(backgroundColor: Color3)
+	return function(props: Props)
+		return React.createElement("TextLabel", {
+			AutomaticSize = Enum.AutomaticSize.XY,
+			BackgroundColor3 = backgroundColor,
+			BorderSizePixel = 0,
+			Font = Enum.Font.BuilderSans,
+			Text = props.controls.label,
+			TextColor3 = Color3.new(1, 1, 1),
+			TextSize = 24,
+		})
+	end
+end
+
+return {
+	name = "Multiple Stories",
+	controls = controls,
+	stories = {
+		{
+			id = "primary",
+			name = "Primary",
+			summary = "The first Story in an ordered array.",
+			story = createStory(Color3.fromRGB(0, 162, 255)),
+		},
+		{
+			id = "secondary",
+			name = "Secondary",
+			summary = "The second Story inherits the module controls.",
+			story = createStory(Color3.fromRGB(163, 75, 255)),
+		},
+	},
+}

--- a/workspace/flipbook-core/src/Storybook/StoryView.luau
+++ b/workspace/flipbook-core/src/Storybook/StoryView.luau
@@ -18,11 +18,10 @@ local View = Foundation.View
 local e = React.createElement
 local useMemo = React.useMemo
 local useSignalState = ReactCharm.useSignalState
-local useStoriesForModule = Storyteller.useStoriesForModule
+local useStory = Storyteller.useStory
 local useOverlay = Foundation.Hooks.useOverlay
 
 type LoadedStorybook = Storyteller.LoadedStorybook
-type LoadedStory = Storyteller.LoadedStory<unknown>
 type ExtraStoryProps = types.ExtraStoryProps
 
 type StoryViewProps = {
@@ -32,22 +31,7 @@ type StoryViewProps = {
 }
 
 local function StoryView(props: StoryViewProps)
-	local stories, storyError = useStoriesForModule(props.storyModule, props.storybook)
-	local story = useMemo(function(): LoadedStory?
-		if not stories then
-			return nil
-		end
-
-		if props.storyId then
-			for _, candidate in stories do
-				if candidate.id == props.storyId then
-					return candidate
-				end
-			end
-		end
-
-		return stories[1]
-	end, { stories, props.storyId } :: { unknown })
+	local story, storyError = useStory(props.storyModule, props.storybook, props.storyId)
 	local theme = useThemeName()
 	local pluginStore = useSignalState(PluginStore.get)
 	local plugin = useSignalState(pluginStore.getPlugin)

--- a/workspace/flipbook-core/src/Storybook/StoryView.luau
+++ b/workspace/flipbook-core/src/Storybook/StoryView.luau
@@ -18,19 +18,36 @@ local View = Foundation.View
 local e = React.createElement
 local useMemo = React.useMemo
 local useSignalState = ReactCharm.useSignalState
-local useStory = Storyteller.useStory
+local useStoriesForModule = Storyteller.useStoriesForModule
 local useOverlay = Foundation.Hooks.useOverlay
 
 type LoadedStorybook = Storyteller.LoadedStorybook
+type LoadedStory = Storyteller.LoadedStory<unknown>
 type ExtraStoryProps = types.ExtraStoryProps
 
 type StoryViewProps = {
+	storyId: string?,
 	storyModule: ModuleScript,
 	storybook: LoadedStorybook,
 }
 
 local function StoryView(props: StoryViewProps)
-	local story, storyError = useStory(props.storyModule, props.storybook)
+	local stories, storyError = useStoriesForModule(props.storyModule, props.storybook)
+	local story = useMemo(function(): LoadedStory?
+		if not stories then
+			return nil
+		end
+
+		if props.storyId then
+			for _, candidate in stories do
+				if candidate.id == props.storyId then
+					return candidate
+				end
+			end
+		end
+
+		return stories[1]
+	end, { stories, props.storyId } :: { unknown })
 	local theme = useThemeName()
 	local pluginStore = useSignalState(PluginStore.get)
 	local plugin = useSignalState(pluginStore.getPlugin)

--- a/workspace/flipbook-core/src/Storybook/StorybookTreeView.luau
+++ b/workspace/flipbook-core/src/Storybook/StorybookTreeView.luau
@@ -5,15 +5,18 @@ local Storyteller = require("@pkg/Storyteller")
 local TreeView = require("@root/TreeView")
 
 local PinnedInstanceStore = require("@root/Storybook/PinnedInstanceStore")
+local createLoadedStorybook = require("@root/Storybook/createLoadedStorybook")
 local createTreeNodeForStoryModule = require("@root/Storybook/createTreeNodeForStoryModule")
 local createTreeNodesForStorybook = require("@root/Storybook/createTreeNodesForStorybook")
+local types = require("@root/Storybook/types")
 local useLastOpenedStory = require("@root/Storybook/useLastOpenedStory")
 local usePrevious = require("@root/Common/usePrevious")
 
 type TreeNodeStore = TreeView.TreeNodeStore
 type LoadedStorybook = Storyteller.LoadedStorybook
 type UnavailableStorybook = Storyteller.UnavailableStorybook
-type LoadedStory<T> = Storyteller.LoadedStory<T>
+type StoryModuleSnapshot = types.StoryModuleSnapshot
+type StoryModuleTarget = types.StoryModuleTarget
 
 local useCallback = React.useCallback
 local useEffect = React.useEffect
@@ -21,22 +24,90 @@ local useMemo = React.useMemo
 local useRef = React.useRef
 local useSignalState = ReactCharm.useSignalState
 local useStorybooks = Storyteller.useStorybooks
+local useStoryModuleSnapshots = Storyteller.useStoryModuleSnapshots
 local useOrphanedStoryModules = Storyteller.useOrphanedStoryModules
 
 export type Props = {
 	searchTerm: string?,
-	onStoryChanged: ((storyModule: ModuleScript?, storybook: LoadedStorybook?) -> ())?,
+	onStoryChanged: ((storyModule: ModuleScript?, storybook: LoadedStorybook?, storyId: string?) -> ())?,
 	onShowErrorPage: ((unavailableStorybook: UnavailableStorybook) -> ())?,
 	layoutOrder: number?,
 }
 
+local function getSnapshotSignature(
+	storyModules: { ModuleScript },
+	snapshots: { [ModuleScript]: StoryModuleSnapshot }
+): string?
+	local parts = {}
+	for _, storyModule in storyModules do
+		local snapshot = snapshots[storyModule]
+		if not snapshot then
+			return nil
+		end
+
+		table.insert(parts, storyModule:GetFullName())
+		table.insert(parts, snapshot.name)
+		table.insert(parts, snapshot.problem or "")
+		for _, story in snapshot.stories do
+			table.insert(parts, story.id)
+			table.insert(parts, story.name)
+		end
+	end
+	return table.concat(parts, "\0")
+end
+
+local function areSameModules(a: { ModuleScript }?, b: { ModuleScript }): boolean
+	if not a or #a ~= #b then
+		return false
+	end
+
+	for index, storyModule in a do
+		if storyModule ~= b[index] then
+			return false
+		end
+	end
+	return true
+end
+
 local function StorybookTreeView(props: Props)
 	local storybookByNodeId = useRef({} :: { [string]: LoadedStorybook })
 	local unavailableStorybookByNodeId = useRef({} :: { [string]: UnavailableStorybook })
+	local snapshotSignaturesByInstance = useRef({} :: { [Instance]: string })
+	local storyModulesByStorybookSource = useRef({} :: { [Instance]: { ModuleScript } })
 	local lastOpenedStory, setLastOpenedStory = useLastOpenedStory()
 	local storybooks = useStorybooks()
 	local orphanedStoryModules = useOrphanedStoryModules()
 	local nodesByInstance = useRef({} :: { [Instance]: TreeNodeStore })
+	local orphanedStorybook = useMemo(createLoadedStorybook, {})
+	local snapshotTargets = useMemo(function(): { StoryModuleTarget }
+		local targets = {}
+		local seen = {}
+
+		for _, storybook in storybooks.available do
+			for _, storyModule in Storyteller.findStoryModulesForStorybook(storybook) do
+				if not seen[storyModule] then
+					seen[storyModule] = true
+					table.insert(targets, {
+						storyModule = storyModule,
+						storybook = storybook,
+					})
+				end
+			end
+		end
+
+		for _, storyModule in orphanedStoryModules do
+			if not seen[storyModule] then
+				seen[storyModule] = true
+				table.insert(targets, {
+					storyModule = storyModule,
+					storybook = orphanedStorybook,
+				})
+			end
+		end
+
+		return targets
+	end, { storybooks.available, orphanedStoryModules, orphanedStorybook } :: { unknown })
+	local storyModuleSnapshots = useStoryModuleSnapshots(snapshotTargets)
 
 	local pinnedInstanceStore = useSignalState(PinnedInstanceStore.get)
 
@@ -118,25 +189,72 @@ local function StorybookTreeView(props: Props)
 	end, { pinnedNodes, prevPinnedNodes, pinned, rootNode } :: { unknown })
 
 	-- Convert available storybooks into nodes
-	useEffect(function()
-		for _, storybook in storybooks.available do
-			if nodesByInstance.current[storybook.source] then
-				continue
+	useEffect(
+		function()
+			for _, storybook in storybooks.available do
+				local storyModules = Storyteller.findStoryModulesForStorybook(storybook)
+				local signature = getSnapshotSignature(storyModules, storyModuleSnapshots)
+				if not signature then
+					continue
+				end
+
+				local previousNode = nodesByInstance.current[storybook.source]
+				if
+					previousNode
+					and snapshotSignaturesByInstance.current[storybook.source] == signature
+					and areSameModules(storyModulesByStorybookSource.current[storybook.source], storyModules)
+				then
+					continue
+				end
+
+				local wasExpanded = if previousNode then previousNode.getIsExpanded() else false
+				local previousSelection = if previousNode
+					then previousNode.findFirstDescendant(function(descendant)
+						return descendant.getIsSelected()
+					end)
+					else nil
+				if previousNode then
+					storybookByNodeId.current[previousNode.id] = nil
+					previousNode.parentTo(nil)
+				end
+
+				local node = createTreeNodesForStorybook(storybook :: any, storyModuleSnapshots)
+				node.setIsExpanded(wasExpanded)
+				nodesByInstance.current[storybook.source] = node
+				snapshotSignaturesByInstance.current[storybook.source] = signature
+				storyModulesByStorybookSource.current[storybook.source] = storyModules
+				storybookByNodeId.current[node.id] = storybook :: any
+
+				if pinnedInstanceStore.isPinned(storybook.source) then
+					node.setIsPinned(true)
+					node.parentTo(pinned)
+				else
+					node.parentTo(rootNode)
+				end
+
+				if previousSelection then
+					local storyModule = previousSelection.getInstance()
+					local storyId = previousSelection.getStoryId()
+					local nextSelection = node.findFirstDescendant(function(descendant)
+						return descendant.getIcon() == TreeView.TreeNodeIcon.Story
+							and descendant.getInstance() == storyModule
+							and descendant.getStoryId() == storyId
+					end)
+					if nextSelection then
+						nextSelection.setIsSelected(true)
+						nextSelection.expandUp()
+					end
+				end
 			end
-
-			local node = createTreeNodesForStorybook(storybook :: any)
-
-			nodesByInstance.current[storybook.source] = node
-			storybookByNodeId.current[node.id] = storybook :: any
-
-			if pinnedInstanceStore.isPinned(storybook.source) then
-				node.setIsPinned(true)
-				node.parentTo(pinned)
-			else
-				node.parentTo(rootNode)
-			end
-		end
-	end, { storybooks.available, pinnedInstanceStore.isPinned, pinned, rootNode } :: { unknown })
+		end,
+		{
+			storybooks.available,
+			storyModuleSnapshots,
+			pinnedInstanceStore.isPinned,
+			pinned,
+			rootNode,
+		} :: { unknown }
+	)
 
 	-- Convert unavailable storybooks into nodes
 	useEffect(function()
@@ -164,16 +282,26 @@ local function StorybookTreeView(props: Props)
 		unknownStories.setIsVisible(#orphanedStoryModules > 0)
 
 		for _, orphan in orphanedStoryModules do
-			if nodesByInstance.current[orphan] then
+			local signature = getSnapshotSignature({ orphan }, storyModuleSnapshots)
+			if not signature then
 				continue
 			end
 
-			local node = createTreeNodeForStoryModule(orphan)
+			local previousNode = nodesByInstance.current[orphan]
+			if previousNode and snapshotSignaturesByInstance.current[orphan] == signature then
+				continue
+			end
 
+			if previousNode then
+				previousNode.parentTo(nil)
+			end
+
+			local node = createTreeNodeForStoryModule(orphan, storyModuleSnapshots[orphan])
 			node.parentTo(unknownStories)
 			nodesByInstance.current[orphan] = node
+			snapshotSignaturesByInstance.current[orphan] = signature
 		end
-	end, { orphanedStoryModules, unknownStories } :: { unknown })
+	end, { orphanedStoryModules, storyModuleSnapshots, unknownStories } :: { unknown })
 
 	-- Handle the removal of any nodes when instances get removed
 	useEffect(function()
@@ -191,6 +319,8 @@ local function StorybookTreeView(props: Props)
 			if not table.find(instances, instance) then
 				node.parentTo(nil)
 				nodesByInstance.current[instance] = nil
+				snapshotSignaturesByInstance.current[instance] = nil
+				storyModulesByStorybookSource.current[instance] = nil
 			end
 		end
 	end, { storybooks.available, storybooks.unavailable, orphanedStoryModules } :: { unknown })
@@ -206,7 +336,9 @@ local function StorybookTreeView(props: Props)
 
 			if lastOpenedStory then
 				local node = rootNode.findFirstDescendant(function(descendant)
-					return descendant.getInstance() == lastOpenedStory
+					return descendant.getIcon() == TreeView.TreeNodeIcon.Story
+						and descendant.getInstance() == lastOpenedStory.storyModule
+						and (lastOpenedStory.storyId == nil or descendant.getStoryId() == lastOpenedStory.storyId)
 				end)
 
 				if node then
@@ -240,12 +372,13 @@ local function StorybookTreeView(props: Props)
 							end)
 
 							local storybook = if storybookNode then storybookByNodeId.current[storybookNode.id] else nil
+							local storyId = selectedNode.getStoryId()
 
-							props.onStoryChanged(instance, storybook)
-							setLastOpenedStory(instance)
+							props.onStoryChanged(instance, storybook, storyId)
+							setLastOpenedStory(instance, storyId)
 						end
 					else
-						props.onStoryChanged(nil, nil)
+						props.onStoryChanged(nil, nil, nil)
 					end
 				end
 

--- a/workspace/flipbook-core/src/Storybook/createTreeNodeForStoryModule.luau
+++ b/workspace/flipbook-core/src/Storybook/createTreeNodeForStoryModule.luau
@@ -1,16 +1,39 @@
 local TreeView = require("@root/TreeView")
+local types = require("@root/Storybook/types")
 
 type TreeNodeStore = TreeView.TreeNodeStore
+type StoryModuleSnapshot = types.StoryModuleSnapshot
 
-local function createTreeNodeForStoryModule(storyModule: ModuleScript): TreeNodeStore
-	local name = storyModule.Name:gsub("%.story", "")
-
+local function createStoryNode(storyModule: ModuleScript, name: string, storyId: string?, order: number?): TreeNodeStore
 	local node = TreeView.createTreeNodeStore()
 	node.setName(name)
+	node.setOrder(order)
 	node.setIcon(TreeView.TreeNodeIcon.Story)
 	node.setInstance(storyModule)
+	node.setStoryId(storyId)
 
 	return node
+end
+
+local function createTreeNodeForStoryModule(storyModule: ModuleScript, snapshot: StoryModuleSnapshot?): TreeNodeStore
+	local moduleName = storyModule.Name:gsub("%.story", "")
+
+	if snapshot and #snapshot.stories > 1 then
+		local groupNode = TreeView.createTreeNodeStore()
+		groupNode.setName(snapshot.name)
+		groupNode.setIcon(TreeView.TreeNodeIcon.Folder)
+		groupNode.setInstance(storyModule)
+
+		for order, story in snapshot.stories do
+			local storyNode = createStoryNode(storyModule, story.name, story.id, order)
+			storyNode.parentTo(groupNode)
+		end
+
+		return groupNode
+	end
+
+	local story = if snapshot then snapshot.stories[1] else nil
+	return createStoryNode(storyModule, moduleName, if story then story.id else nil, nil)
 end
 
 return createTreeNodeForStoryModule

--- a/workspace/flipbook-core/src/Storybook/createTreeNodeForStoryModule.spec.luau
+++ b/workspace/flipbook-core/src/Storybook/createTreeNodeForStoryModule.spec.luau
@@ -1,0 +1,58 @@
+local JestGlobals = require("@pkg/JestGlobals")
+
+local TreeView = require("@root/TreeView")
+local createTreeNodeForStoryModule = require("./createTreeNodeForStoryModule")
+
+local expect = JestGlobals.expect
+local test = JestGlobals.test
+
+test("keeps single-story modules as one leaf", function()
+	local storyModule = Instance.new("ModuleScript")
+	storyModule.Name = "Button.story"
+
+	local node = createTreeNodeForStoryModule(storyModule, {
+		name = "Buttons",
+		source = storyModule,
+		stories = {
+			{
+				id = "default",
+				name = "Primary",
+			},
+		},
+	})
+
+	expect(node.getName()).toBe("Button")
+	expect(node.getIcon()).toBe(TreeView.TreeNodeIcon.Story)
+	expect(node.getStoryId()).toBe("default")
+	expect(#node.getChildren()).toBe(0)
+end)
+
+test("creates an ordered group for multi-story modules", function()
+	local storyModule = Instance.new("ModuleScript")
+	storyModule.Name = "Button.story"
+
+	local node = createTreeNodeForStoryModule(storyModule, {
+		name = "Buttons",
+		source = storyModule,
+		stories = {
+			{
+				id = "secondary",
+				name = "Secondary",
+			},
+			{
+				id = "primary",
+				name = "Primary",
+			},
+		},
+	})
+	local children = node.getChildren()
+
+	expect(node.getName()).toBe("Buttons")
+	expect(node.getIcon()).toBe(TreeView.TreeNodeIcon.Folder)
+	expect(children[1].getName()).toBe("Secondary")
+	expect(children[1].getStoryId()).toBe("secondary")
+	expect(children[1].getOrder()).toBe(1)
+	expect(children[2].getName()).toBe("Primary")
+	expect(children[2].getStoryId()).toBe("primary")
+	expect(children[2].getOrder()).toBe(2)
+end)

--- a/workspace/flipbook-core/src/Storybook/createTreeNodesForStorybook.luau
+++ b/workspace/flipbook-core/src/Storybook/createTreeNodesForStorybook.luau
@@ -3,19 +3,23 @@ local Storyteller = require("@pkg/Storyteller")
 local TreeView = require("@root/TreeView")
 local createTreeNodeForStoryModule = require("@root/Storybook/createTreeNodeForStoryModule")
 local getAncestors = require("@root/Common/getAncestors")
+local types = require("@root/Storybook/types")
 
 type TreeNodeStore = TreeView.TreeNodeStore
 type LoadedStorybook = Storyteller.LoadedStorybook
-type LoadedStory<any> = Storyteller.LoadedStory<any>
+type StoryModuleSnapshot = types.StoryModuleSnapshot
 
-local function createTreeNodesForStorybook(storybook: LoadedStorybook): TreeNodeStore
+local function createTreeNodesForStorybook(
+	storybook: LoadedStorybook,
+	snapshots: { [ModuleScript]: StoryModuleSnapshot }?
+): TreeNodeStore
 	local root = TreeView.createTreeNodeStore()
 	root.setName(if storybook.name then storybook.name else "Unnamed Storybook")
 	root.setIcon(TreeView.TreeNodeIcon.Storybook)
 	root.setInstance(storybook.source)
 
 	for _, storyModule in Storyteller.findStoryModulesForStorybook(storybook) do
-		local currentNode = createTreeNodeForStoryModule(storyModule)
+		local currentNode = createTreeNodeForStoryModule(storyModule, if snapshots then snapshots[storyModule] else nil)
 
 		for _, ancestor in getAncestors(storyModule) do
 			-- This is probably expensive to be doing so frequently but it seems

--- a/workspace/flipbook-core/src/Storybook/types.luau
+++ b/workspace/flipbook-core/src/Storybook/types.luau
@@ -1,7 +1,9 @@
 local CommonTypes = require("@root/Common/types")
+local Storyteller = require("@pkg/Storyteller")
 local useThemeName = require("@root/Common/useThemeName")
 
 type Pluginlike = CommonTypes.Pluginlike
+type LoadedStorybook = Storyteller.LoadedStorybook
 type ThemeName = useThemeName.ThemeName
 
 export type ExtraStoryProps = {
@@ -13,6 +15,24 @@ export type ExtraStoryProps = {
 	-- value. And I didn't want to do that yet
 	plugin: Pluginlike?,
 	widget: GuiBase2d?,
+}
+
+export type StorySnapshot = {
+	id: string,
+	name: string,
+	summary: string?,
+}
+
+export type StoryModuleSnapshot = {
+	name: string,
+	source: ModuleScript,
+	stories: { StorySnapshot },
+	problem: string?,
+}
+
+export type StoryModuleTarget = {
+	storyModule: ModuleScript,
+	storybook: LoadedStorybook,
 }
 
 return nil

--- a/workspace/flipbook-core/src/Storybook/useLastOpenedStory.luau
+++ b/workspace/flipbook-core/src/Storybook/useLastOpenedStory.luau
@@ -11,22 +11,28 @@ local useCallback = React.useCallback
 local useMemo = React.useMemo
 local useSignalState = ReactCharm.useSignalState
 
-local function useLastOpenedStory(): (ModuleScript?, (storyModule: ModuleScript?) -> ())
+export type LastOpenedStory = {
+	storyId: string?,
+	storyModule: ModuleScript,
+}
+
+local function useLastOpenedStory(): (LastOpenedStory?, (storyModule: ModuleScript?, storyId: string?) -> ())
 	local localStorageStore = useSignalState(LocalStorageStore.get)
 	local localStorage = useSignalState(localStorageStore.getStorage)
 
 	local userSettingsStore = useSignalState(UserSettingsStore.get)
 	local userSettings = useSignalState(userSettingsStore.getStorage)
 
-	local setLastOpenedStory = useCallback(function(storyModule: ModuleScript?)
+	local setLastOpenedStory = useCallback(function(storyModule: ModuleScript?, storyId: string?)
 		localStorageStore.setStorage(function(prev)
 			return Sift.Dictionary.join(prev, {
+				lastOpenedStoryId = if storyModule then storyId else nil,
 				lastOpenedStoryPath = if storyModule then getInstancePath(storyModule) else nil,
 			})
 		end)
 	end, { localStorageStore })
 
-	local lastOpenedStory = useMemo(function(): ModuleScript?
+	local lastOpenedStory = useMemo(function(): LastOpenedStory?
 		local rememberLastOpenedStory = userSettings.rememberLastOpenedStory
 
 		if not rememberLastOpenedStory then
@@ -39,7 +45,10 @@ local function useLastOpenedStory(): (ModuleScript?, (storyModule: ModuleScript?
 			local instance = getInstanceFromPath(lastOpenedStoryPath)
 
 			if instance and instance:IsA("ModuleScript") then
-				return instance
+				return {
+					storyId = localStorage.lastOpenedStoryId,
+					storyModule = instance,
+				}
 			end
 		end
 

--- a/workspace/flipbook-core/src/TreeView/TreeView.luau
+++ b/workspace/flipbook-core/src/TreeView/TreeView.luau
@@ -25,7 +25,12 @@ local function TreeView(props: Props)
 
 	useEffect(function()
 		props.root.setSortOrder(function(a: TreeNodeStore, b: TreeNodeStore)
-			if a.getIcon() ~= b.getIcon() then
+			local aOrder = a.getOrder()
+			local bOrder = b.getOrder()
+
+			if aOrder ~= nil and bOrder ~= nil then
+				return aOrder < bOrder
+			elseif a.getIcon() ~= b.getIcon() then
 				-- Sort by type
 				return a.getIcon() < b.getIcon()
 			else

--- a/workspace/flipbook-core/src/TreeView/createTreeNodeStore.luau
+++ b/workspace/flipbook-core/src/TreeView/createTreeNodeStore.luau
@@ -15,6 +15,7 @@ local function createTreeNodeStore(): TreeNodeStore
 	local id = HttpService:GenerateGUID()
 
 	local getName, setName = Charm.signal("Node")
+	local getOrder, setOrder = Charm.signal(nil :: number?)
 	local getIcon, setIcon = Charm.signal(nil :: TreeNodeIcon?)
 	local getIsSelected, setIsSelected = Charm.signal(false)
 	local getIsExpanded, setIsExpanded = Charm.signal(false)
@@ -23,6 +24,7 @@ local function createTreeNodeStore(): TreeNodeStore
 	local getIsPinned, setIsPinned = Charm.signal(false)
 
 	local getInstance, setInstance = Charm.signal(nil :: Instance?)
+	local getStoryId, setStoryId = Charm.signal(nil :: string?)
 
 	local getParent, setParent = Charm.signal(nil :: TreeNodeStore?)
 	local getUnsortedChildren, setUnsortedChildren = Charm.signal({} :: { TreeNodeStore })
@@ -246,6 +248,8 @@ local function createTreeNodeStore(): TreeNodeStore
 		-- Node properties and states
 		getName = getName,
 		setName = setName,
+		getOrder = getOrder,
+		setOrder = setOrder,
 		getIcon = getIcon :: () -> TreeNodeIcon?,
 		setIcon = (setIcon :: any) :: CharmTypes.Setter<TreeNodeIcon?>,
 		getIsVisible = getIsVisible,
@@ -285,6 +289,8 @@ local function createTreeNodeStore(): TreeNodeStore
 		-- DataModel
 		getInstance = getInstance,
 		setInstance = setInstance,
+		getStoryId = getStoryId,
+		setStoryId = setStoryId,
 
 		-- Other
 		snapshot = snapshot,

--- a/workspace/flipbook-core/src/TreeView/createTreeNodeStore.spec.luau
+++ b/workspace/flipbook-core/src/TreeView/createTreeNodeStore.spec.luau
@@ -28,6 +28,18 @@ test("nodes can be named", function()
 	expect(root.getName()).toBe("<root>")
 end)
 
+test("nodes can identify and order stories", function()
+	local node = createTreeNodeStore()
+	expect(node.getStoryId()).toBeUndefined()
+	expect(node.getOrder()).toBeUndefined()
+
+	node.setStoryId("primary")
+	node.setOrder(2)
+
+	expect(node.getStoryId()).toBe("primary")
+	expect(node.getOrder()).toBe(2)
+end)
+
 describe("node activation", function()
 	test("activating a node with no children changes its selected state", function()
 		local root = createTreeNodeStore()

--- a/workspace/flipbook-core/src/TreeView/types.luau
+++ b/workspace/flipbook-core/src/TreeView/types.luau
@@ -23,6 +23,8 @@ export type TreeNodeStore = {
 	-- Node properties and states
 	getName: CharmTypes.Getter<string>,
 	setName: CharmTypes.Setter<string>,
+	getOrder: CharmTypes.Getter<number?>,
+	setOrder: CharmTypes.Setter<number?>,
 	getIcon: CharmTypes.Getter<TreeNodeIcon?>,
 	setIcon: CharmTypes.Setter<TreeNodeIcon?>,
 	getIsSelected: CharmTypes.Getter<boolean>,
@@ -62,6 +64,8 @@ export type TreeNodeStore = {
 	-- DataModel
 	getInstance: CharmTypes.Getter<Instance?>,
 	setInstance: CharmTypes.Setter<Instance?>,
+	getStoryId: CharmTypes.Getter<string?>,
+	setStoryId: CharmTypes.Setter<string?>,
 
 	-- Other
 	snapshot: () -> TreeNodeSnapshot,


### PR DESCRIPTION
## Summary
- render multi-story modules as nested, author-ordered sidebar entries
- preserve the selected story ID through navigation, rendering, and last-opened persistence
- use Storyteller snapshots for sidebar metadata while loading full stories only when selected

Depends on flipbook-labs/storyteller#142.

## Test plan
- [x] `lute run lint`
- [x] `lute run analyze`
- [x] `lute run test` (80 passed, 1 skipped)
- [x] clean development plugin build with the Storyteller overlay
- [x] verify Foundation loads in Studio without a script timeout

Made with [Cursor](https://cursor.com)