### PR TITLE
Separate Studio validation scenarios

### DIFF
--- a/.agents/skills/flipbook-change-control/SKILL.md
+++ b/.agents/skills/flipbook-change-control/SKILL.md
@@ -20,14 +20,7 @@ All work proceeds through feature branches and pull requests. **Never commit dir
 
 ### Pull Requests
 
-**Template:** Use the template at `.github/pull_request_template.md` (verified 2026-07-01).
-
-```markdown
-## Problem
-## Solution
-## Testing
-## Notes for reviewers
-```
+**Template:** Use the template at `.github/pull_request_template.md`.
 
 Fill every section concisely. The Problem/Solution should describe what the change does in present tense on its own ("Add a foo helper to consolidate X"), not its origin story.
 
@@ -35,7 +28,9 @@ Fill every section concisely. The Problem/Solution should describe what the chan
 
 **Disclosure:** Every PR body must disclose AI assistance (e.g., closing line: "🤖 Generated with [Claude Code](https://claude.com/claude-code)"). This is mandatory per user convention and applies even when filling a repo's PR template.
 
-**Review routing:** `CODEOWNERS` at the repo root assigns all paths (`*`) to `@flipbook-labs/flipbook-maintainers` and `@flipbook-labs/flipbook-contributors` (verified 2026-07-01), so every PR automatically requests review from those teams — there is no per-directory ownership split.
+**Review routing:** `.github/MERGE_POLICY.md` is the policy source of truth, and the [Flipbook Labs GitHub governance stack](https://github.com/flipbook-labs/infra/tree/main/stacks/github) manages the live ownership and enforcement configuration. Ownership is inferred from changed files. Application changes require one human application-team approval. While the engine team has one member, engine changes require no human approval but still require the current Greptile 5/5 status and all applicable CI; increase the engine minimum to one approval when a second member joins. Mixed changes follow both paths. Repository-stewardship changes belong to `@flipbook-labs/flipbook-admins`, the catch-all team with blanket organization permissions, and have no separate human-approval requirement or path-based ruleset.
+
+**Greptile findings:** Evaluate each finding. Fix valid findings; respond with repository evidence and request another review when a finding is invalid. If Greptile retains a finding, the code must change unless a member of `@flipbook-labs/flipbook-admins` chooses to bypass the required status. Agents never bypass merge requirements.
 
 ### Commit Hygiene
 
@@ -54,6 +49,7 @@ Releasing Flipbook is gated and automated — no manual tag pushes, no direct ve
 **Only method:** `lute run bump-version <major|minor|patch>` (verified in repo `.lute/` scripts).
 
 This is the single authoritative version source. The command:
+
 1. Bumps `package.toml` (or equivalent version file)
 2. Creates a release commit
 3. Tags the commit with the new version
@@ -76,11 +72,11 @@ Never edit version strings by hand or push tags directly.
 
 Flipbook has three build channels (verified in `ci.yml` matrix: dev/beta/prod, and `.lute/build.luau`):
 
-| Channel | Use | Keeps | Prunes |
-|---------|-----|-------|--------|
-| **dev** | local dev, CI proof | tests, stories, storybooks, example/ | — |
-| **beta** | internal validation (experimental) | same as dev | — |
-| **prod** | release to Creator Store, end users | core plugin only | `code-samples/`, `example/`, `template/`, `test-runner/`, `*.spec.luau`, `*.story.luau`, `*.storybook.luau`, `jest.config.luau*` |
+| Channel  | Use                                 | Keeps                                | Prunes                                                                                                                           |
+| -------- | ----------------------------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| **dev**  | local dev, CI proof                 | tests, stories, storybooks, example/ | —                                                                                                                                |
+| **beta** | internal validation (experimental)  | same as dev                          | —                                                                                                                                |
+| **prod** | release to Creator Store, end users | core plugin only                     | `code-samples/`, `example/`, `template/`, `test-runner/`, `*.spec.luau`, `*.story.luau`, `*.storybook.luau`, `jest.config.luau*` |
 
 Default channel is `prod`. Pass `--channel dev` or `--channel beta` to `lute run build` to retain development files.
 
@@ -92,6 +88,10 @@ Default channel is `prod`. Pass `--channel dev` or `--channel beta` to `lute run
 
 Every PR must pass the following gate jobs before merge is recommended:
 
+### Greptile review
+
+Greptile must report 5/5 for the pull request's current head commit. The required status is an output of that review rather than a second review. Each completed review counts as one Greptile review, including a review triggered after another commit, so batch related fixes when practical.
+
 ### `ci.yml` — Standard Build & Attestation
 
 **Trigger:** every push to main, every PR to main, manual dispatch.
@@ -99,11 +99,13 @@ Every PR must pass the following gate jobs before merge is recommended:
 **Build matrix:** channels `dev`, `beta`, `prod` × targets `plugin`, `flipbook-core-rotriever`.
 
 **What it proves:**
+
 - Source → Darklua → Rojo pipeline succeeds for all channels.
 - Build artifacts are reproducible (provenance attestation via GitHub Attestations API, verified 2026-07-01).
 - No syntax errors or broken requires.
 
 **Fails if:**
+
 - `lute run build plugin --channel <X>` fails.
 - Sourcemap resolution breaks.
 - Darklua dead-code elimination fails.
@@ -130,6 +132,7 @@ Every PR must pass the following gate jobs before merge is recommended:
    - **Fails if:** publish fails (e.g., malformed rbxm, asset mismatch).
 
 **Environment Gating:** (verified in `.github/workflows/strict.yml`, grep the conditional `environment:` job key)
+
 - **Fork PRs** (external contributions): `luau-execution-gated` environment requires approval.
 - **Internal PRs** (from flipbook-labs org): `luau-execution` environment (auto-approved).
 - **Main/manual:** runs without gating.
@@ -141,11 +144,13 @@ Every PR must pass the following gate jobs before merge is recommended:
 **Trigger:** every PR, every push to main.
 
 **What it proves:**
+
 - `lute run build storybook` (the test place bundle) succeeds.
 - Storybook can deploy to a place via `flipbook-labs/deploy-storybook@v0.4.0` (verified 2026-07-01).
 - Dev/beta builds can sync to Studio without errors.
 
 **Fails if:**
+
 - Rojo workspace sync fails.
 - deploy-storybook GitHub Action fails.
 
@@ -156,6 +161,7 @@ Every PR must pass the following gate jobs before merge is recommended:
 **Trigger:** every PR, every push to main (as part of `ci.yml`'s `analyze` job).
 
 **What it proves:**
+
 - No Selene lint violations (`std = "roblox"`, `global_usage = "allow"`).
 - StyLua formatting (`sort_requires = true`, verified in `stylua.toml`).
 - Prettier markdown formatting.
@@ -169,16 +175,16 @@ Every PR must pass the following gate jobs before merge is recommended:
 
 Use this table to determine which CI gates your change requires and whether it is safe.
 
-| Change Type | Behavior Change | Test Payload | Required Gates | Notes |
-|-------------|-----------------|--------------|----------------|-------|
-| Plugin code (`.luau` in `src/` or `workspace/flipbook-core/src/`) | Yes | Yes | `ci.yml` + `strict.yml` | All logic changes; story render, controls, theme/locale, navigation, permissions, etc. |
-| Build script (`.lute/`, `darklua.json`, `wally.toml`) | Conditional | Varies | `ci.yml` | If it changes build output (e.g., new global, new pruned file), re-run full matrix. If it only touches tooling setup, `ci.yml` alone may suffice; but always err toward strict.yml. |
-| Test (`*.spec.luau`) | No | Yes | `ci.yml` + `strict.yml` | New tests; updated test fixtures. Must pass in cloud. |
-| Story or storybook (`*.story.luau`, `*.storybook.luau`) | No | No | `storybook.yml` + `ci.yml` | Dev channel only (pruned in prod); no impact on end users. |
-| CI workflow (`.github/workflows/*.yml`) | No | No | Manual re-run of affected workflow | Changes to job conditions, artifact handling, secrets wiring, environment gating. |
-| Documentation (`.md`, docs vault, AGENTS.md) | No | No | `docs.yml` (if exists); linting only | No code impact. Markdown must pass Prettier. |
-| Type definitions, aliases (`.luaurc`) | Conditional | Possibly | `ci.yml` + `strict.yml` | Language mode or alias changes affect all downstream analysis. |
-| Dependencies (Wally `wally.toml`, Loom, Rokit versions) | Yes | Maybe | `ci.yml` + `strict.yml` + manual local test | **See "Dependency Change Discipline" below.** |
+| Change Type                                                       | Behavior Change | Test Payload | Required Gates                              | Notes                                                                                                                                                                               |
+| ----------------------------------------------------------------- | --------------- | ------------ | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Plugin code (`.luau` in `src/` or `workspace/flipbook-core/src/`) | Yes             | Yes          | `ci.yml` + `strict.yml`                     | All logic changes; story render, controls, theme/locale, navigation, permissions, etc.                                                                                              |
+| Build script (`.lute/`, `darklua.json`, `wally.toml`)             | Conditional     | Varies       | `ci.yml`                                    | If it changes build output (e.g., new global, new pruned file), re-run full matrix. If it only touches tooling setup, `ci.yml` alone may suffice; but always err toward strict.yml. |
+| Test (`*.spec.luau`)                                              | No              | Yes          | `ci.yml` + `strict.yml`                     | New tests; updated test fixtures. Must pass in cloud.                                                                                                                               |
+| Story or storybook (`*.story.luau`, `*.storybook.luau`)           | No              | No           | `storybook.yml` + `ci.yml`                  | Dev channel only (pruned in prod); no impact on end users.                                                                                                                          |
+| CI workflow (`.github/workflows/*.yml`)                           | No              | No           | Manual re-run of affected workflow          | Changes to job conditions, artifact handling, secrets wiring, environment gating.                                                                                                   |
+| Documentation (`.md`, docs vault, AGENTS.md)                      | No              | No           | `docs.yml` (if exists); linting only        | No code impact. Markdown must pass Prettier.                                                                                                                                        |
+| Type definitions, aliases (`.luaurc`)                             | Conditional     | Possibly     | `ci.yml` + `strict.yml`                     | Language mode or alias changes affect all downstream analysis.                                                                                                                      |
+| Dependencies (Wally `wally.toml`, Loom, Rokit versions)           | Yes             | Maybe        | `ci.yml` + `strict.yml` + manual local test | **See "Dependency Change Discipline" below.**                                                                                                                                       |
 
 ---
 
@@ -219,6 +225,7 @@ When updating a Wally dependency in `wally.toml` (e.g., Storyteller, ModuleLoade
    - Reason: partial builds can hide missing or broken transitive requires.
 
 2. **Test locally** before opening a PR:
+
    ```bash
    lute run build plugin --channel dev --clean
    lute run lint
@@ -241,6 +248,7 @@ Loom manages tooling packages (`.lute/` scripts use these). Upgrades are high-ri
 - Branch `upgrade-loom-dependencies` stalled 53 days (as of 2026-07-01) after "nightmare" fixes.
 
 **Discipline:** Upgrade Loom/Lute only if necessary. If you do:
+
 1. Test on macOS and Ubuntu (process spawning differs).
 2. Run `--clean` full builds locally.
 3. Document breaking API changes in the PR.
@@ -269,6 +277,7 @@ Flipbook is being brought to internal Roblox teams, but the internal build must 
 ### In Practice
 
 Before merging a feature or fix:
+
 - Ask: "Would a community user (or external creator in Roblox Studio) be able to use this?"
 - If no, the feature is either not ready or not appropriate for this repo.
 - Blocked features belong on a roadmap or research branch, not main.
@@ -340,6 +349,7 @@ These rules have been tested by production failures and are now enforced.
 **Rule:** Releases happen via `lute run bump-version` + GitHub Release, never `git push origin <tag>`.
 
 **Incidents:**
+
 - **PR #535 "Fix broken nightly build"** (2026-03-20): Darklua failed to resolve string requires; symptom was nightly builds failing to publish. Root cause was path format sensitivity in Darklua.
 - **PR #561 "Fix dev deployments triggering for all PRs"** (2026-04-18): Dev build deployed from every PR after fork-workflow switch. Root cause: `pull_request_target` always runs; condition was broken.
 - **PR #562 "Fix smoketest deployments cancelling each other"** (2026-04-18): Smoketest concurrency config interfered with approval gates.
@@ -354,6 +364,7 @@ All of these stemmed from manual coordination between tags, release workflow, an
 **Rule:** `src/PluginStarterScript.plugin.luau` (comment block above `Charm.flags.frozen = false`, verified 2026-07-01; grep `Normally we want this to be`) sets `Charm.flags.frozen = false`. Do not remove this line.
 
 **Incident (Signals→Charm Migration, PR #509, Storyteller #100):**
+
 - PR #509 migrated from Signals to Charm for state management.
 - Storyteller's internal state mutation hits `Charm.flags.frozen = true` and crashes with "Attempt to modify a readonly table."
 - Root cause: Storyteller is mutating immutable state in a context-dependent way (lives in storyteller#100).
@@ -375,6 +386,7 @@ All of these stemmed from manual coordination between tags, release workflow, an
 **Rule:** Comments explain why code is the way it is **now**, for a reader seeing it for the first time. Do not write comments that only make sense as a diff against past shapes.
 
 **Anti-Pattern:**
+
 ```luau
 -- This used to be inline; the logic now lives in X.
 -- Where did all the release logic go? It moved to Y.
@@ -382,6 +394,7 @@ All of these stemmed from manual coordination between tags, release workflow, an
 ```
 
 **Pattern:**
+
 ```luau
 -- Charm.flags.frozen = false works around Storyteller issue #100 (readonly table mutation).
 ```
@@ -398,27 +411,34 @@ All of these stemmed from manual coordination between tags, release workflow, an
 
 Quick reference for determining what CI gates a change needs.
 
-| Change Scope | Gate: ci.yml | Gate: strict.yml | Gate: storybook.yml | Notes |
-|--------------|--------------|------------------|---------------------|-------|
-| Plugin code (logic, UI, telemetry) | ✅ | ✅ | ✅ if affects story render | Always required for user-facing changes |
-| Tests (*.spec.luau) | ✅ | ✅ | — | Runs in cloud; must pass |
-| Stories/storybooks (*.story.luau, *.storybook.luau) | ✅ | — | ✅ | Dev-only; not in prod builds |
-| Build scripts (.lute/, darklua.json) | ✅ | ✅ if output changes | — | Use --clean locally to test |
-| Wally/Loom/Rokit versions | ✅ | ✅ | — | High-risk; test local --clean build first |
-| CI workflows (.github/workflows/*.yml) | — | Manual re-run | — | Test in draft PR before merging |
-| Docs (.md, docs vault) | ✅ linting only | — | — | No code impact; Prettier only |
-| `.luaurc`, language config | ✅ | ✅ | — | Language mode changes affect all files |
+| Change Scope                                        | Gate: ci.yml    | Gate: strict.yml     | Gate: storybook.yml        | Notes                                     |
+| --------------------------------------------------- | --------------- | -------------------- | -------------------------- | ----------------------------------------- |
+| Plugin code (logic, UI, telemetry)                  | ✅              | ✅                   | ✅ if affects story render | Always required for user-facing changes   |
+| Tests (*.spec.luau)                                 | ✅              | ✅                   | —                          | Runs in cloud; must pass                  |
+| Stories/storybooks (*.story.luau, *.storybook.luau) | ✅              | —                    | ✅                         | Dev-only; not in prod builds              |
+| Build scripts (.lute/, darklua.json)                | ✅              | ✅ if output changes | —                          | Use --clean locally to test               |
+| Wally/Loom/Rokit versions                           | ✅              | ✅                   | —                          | High-risk; test local --clean build first |
+| CI workflows (.github/workflows/*.yml)              | —               | Manual re-run        | —                          | Test in draft PR before merging           |
+| Docs (.md, docs vault)                              | ✅ linting only | —                    | —                          | No code impact; Prettier only             |
+| `.luaurc`, language config                          | ✅              | ✅                   | —                          | Language mode changes affect all files    |
 
 ---
 
 ## Provenance and Maintenance
 
-**Last verified:** 2026-07-01 (against shared-brief.md, archaeology, flipbook-docs branch, repo files).
+**Last verified:** 2026-09-08 (against `.github/MERGE_POLICY.md`, the live GitHub ruleset, the pull request template, repository workflows, and repo files).
 
 **Re-verification commands:**
+
 ```bash
 # Confirm PR template exists and is current
 cat .github/pull_request_template.md
+
+# Confirm merge policy is current
+cat .github/MERGE_POLICY.md
+
+# Inspect the live ruleset; its configuration is managed in flipbook-labs/infra
+gh api repos/flipbook-labs/flipbook/rulesets
 
 # Confirm CI/strict/storybook workflows exist
 ls -la .github/workflows/{ci,strict,storybook}.yml
@@ -437,6 +457,7 @@ ls .agents/skills/test-dependencies-in-flipbook/SKILL.md
 ```
 
 **Known drift risks:**
+
 - Release workflow changes (rbxasset.toml, Creator Store asset IDs): re-check release.yml every quarter.
 - CI environment gating (fork vs. internal): re-check strict.yml if fork-workflow issues resurface.
 - Storyteller/ModuleLoader APIs: if those skills advance, confirm change-control gates still align.

--- a/.agents/skills/use-studio-mcp-for-flipbook/SKILL.md
+++ b/.agents/skills/use-studio-mcp-for-flipbook/SKILL.md
@@ -1,9 +1,16 @@
 ---
 name: use-studio-mcp-for-flipbook
 description: Work on Flipbook's Studio MCP and FlipbookAgentGateway integration from inside the Flipbook repo. Use when editing gateway actions, gateway instructions, .mcp.json, or validating a local Flipbook plugin build in Roblox Studio.
+type: process
 ---
 
 # Use StudioMCP For Flipbook
+
+This skill covers Flipbook-specific development and validation through Studio MCP. It keeps gateway interaction scenario-neutral so each behavior can supply its own fixture and assertions.
+
+## When not to use
+
+For the generic AgentGateway protocol, read the shared `agent-gateway/use-agent-gateway` skill. For local Storyteller or ModuleLoader overlays, read `test-dependencies-in-flipbook`. For the multi-story fixture and its acceptance criteria, read [`references/multi-story.md`](references/multi-story.md).
 
 ## When To Use
 
@@ -86,70 +93,15 @@ Recommended validation sequence after changing gateway code or instructions:
 7. Poll readiness before `setControls` or mounted-story actions
 8. `setControls`, `getScreen`, `getStoryActions`, and any changed action
 
-For the bundled multi-story renderer check, use the `Agent Multi-Story E2E`
-storybook and its `MultipleStories.story` module. That storybook intentionally
-omits FlipbookCore's `mapStory` provider wrapper so the check isolates concrete
-story selection and rendering from FlipbookCore's own nested storybook context.
+`setControls` requires the story view to be mounted. Do not use a fixed sleep. For stories with controls, poll for the newly opened story and an expected control key before calling it. For viewport-preview checks, call `viewportPreview` and then poll `getStoryActions.isMountedInViewport`.
 
-`setControls` requires the story view to be mounted. Do not use a fixed sleep. For stories with controls, poll for the newly-opened story and an expected control key before calling it. For viewport-preview checks, call `viewportPreview` and then poll `getStoryActions.isMountedInViewport`.
+Behavior-specific validation belongs in a scenario reference beside this skill. A scenario names its fixture selectors, actions, semantic assertions, and any visual evidence without changing the gateway workflow above.
 
-```lua
-local HttpService = game:GetService("HttpService")
-local CoreGui = game:GetService("CoreGui")
-local gateway = CoreGui:FindFirstChild("FlipbookAgentGateway")
-assert(gateway ~= nil, "missing FlipbookAgentGateway")
+## Visual Checks
 
-local storyPath = "ReplicatedStorage.Example.Stories.Button.story"
-local storyId = "primary"
-local expectedControlKey = "label"
+Studio MCP viewport captures do not include plugin dock widgets. When the agent host can inspect the native Studio window, leave the requested Story open in Flipbook and capture or inspect the dock widget directly.
 
-gateway:Invoke({
-	method = "call",
-	action = "openStory",
-	params = {
-		story = storyPath,
-		storyId = storyId,
-	},
-})
-
-local ready = false
-for _ = 1, 60 do
-	local currentStory = gateway:Invoke({ method = "call", action = "getCurrentStory" })
-	local controls = gateway:Invoke({ method = "call", action = "getControls" })
-
-	if
-		currentStory.ok
-		and currentStory.result ~= nil
-		and currentStory.result.id == storyId
-		and currentStory.result.isMounted
-		and controls.ok
-		and controls.result ~= nil
-		and controls.result.controls ~= nil
-		and controls.result.controls[expectedControlKey] ~= nil
-	then
-		ready = true
-		break
-	end
-
-	task.wait()
-end
-
-assert(ready, "story did not become ready for controls")
-
-local result = gateway:Invoke({
-	method = "call",
-	action = "setControls",
-	params = {
-		controls = {
-			label = "Clicked",
-		},
-	},
-})
-
-return HttpService:JSONEncode(result)
-```
-
-## Embedded Visual Checks
+When only Studio MCP viewport capture is available, embed Flipbook into the place before entering play mode:
 
 ```lua
 local HttpService = game:GetService("HttpService")
@@ -169,7 +121,7 @@ local result = gateway:Invoke({
 return HttpService:JSONEncode(result)
 ```
 
-After embedding, use `start_stop_play { is_start = true }`, wait for the client data model to be available, and take `screen_capture`. If the screenshot is blank or not the Studio viewport, ask the user to bring Studio to the foreground before retrying.
+After embedding, use `start_stop_play { is_start = true }`, wait for the client data model to be available, and take `screen_capture`. Inspect client errors and stop the visual check if the embedded UI does not mount; do not substitute a blank capture for evidence. If the screenshot is not the Studio viewport, ask the user to bring Studio to the foreground before retrying.
 
 Stop play mode with `start_stop_play { is_start = false }` when done unless the user asks to leave the experience running.
 
@@ -183,3 +135,16 @@ When changing how agents should interact with Flipbook, update `getInstructions`
 - Explain Studio MCP blockers that external agents can recognize.
 
 When changing a specific action, update that action's manifest metadata (`title`, `description`, and `inputSchema`) so `method = "list"` stays self-service. If the AgentGateway package cannot express the needed level of information, update AgentGateway rather than compensating in this skill.
+
+---
+
+## Provenance and Maintenance
+
+**Date stamped:** 2026-09-06. Verified against the `FlipbookAgentGateway` action manifest, the Studio MCP configuration in `.mcp.json`, and the local plugin and Storybook build tasks.
+
+**Re-verify these claims when this skill next loads:**
+
+- Gateway instructions and action metadata: inspect `INSTRUCTIONS` and `create` in `workspace/flipbook-core/src/Agent/actions.luau`.
+- Studio MCP registration: inspect `.mcp.json`.
+- Build commands: run `lute run build plugin --channel dev --clean` and `lute run build storybook --channel dev --clean`.
+- Scenario references: list `.agents/skills/use-studio-mcp-for-flipbook/references/`.

--- a/.agents/skills/use-studio-mcp-for-flipbook/references/multi-story.md
+++ b/.agents/skills/use-studio-mcp-for-flipbook/references/multi-story.md
@@ -1,0 +1,31 @@
+# Multi-story integration scenario
+
+Use this scenario to prove that Flipbook can discover, select, render, and control more than one concrete Story exported by the same module. Follow the connection, discovery, readiness, and visual-check workflow in the parent [`use-studio-mcp-for-flipbook`](../SKILL.md) skill.
+
+## Fixture
+
+- Storybook name: `Agent Multi-Story E2E`
+- Story module suffix: `MultipleStories.story`
+- Concrete Stories: `Primary` with id `primary`, and `Secondary` with id `secondary`
+- Expected control: `label`
+- Expected previews: blue for Primary and purple for Secondary
+
+The Storybook omits FlipbookCore's `mapStory` provider wrapper so the scenario isolates concrete Story selection and rendering from FlipbookCore's nested Storybook context.
+
+## Semantic proof
+
+1. Call `listStorybooks` and select the result named `Agent Multi-Story E2E`. A built Storybook place can expose both runtime and plugin-debug copies; when more than one result has that name, select the returned path rooted at `ReplicatedStorage.FlipbookWorkspace`.
+2. Call `listStories` with that result's path. Select the two results whose module path ends in `MultipleStories.story`; use the returned paths and ids in later calls.
+3. For each concrete Story, call `openStory` with the returned module path, Storybook path, and id.
+4. Poll `getCurrentStory` until its id matches the requested id and `isMounted` is true. Poll `getControls` until the `label` control exists.
+5. Set a distinct label with `setControls`, then confirm the value through `getControls`.
+
+Record the discovered paths and returned ids as evidence. The scenario must not depend on a hard-coded DataModel path.
+
+## Visual proof
+
+After both concrete Stories pass semantic verification, turn viewport preview off, leave each Story open in turn, and inspect the native Studio window. Confirm that Primary shows the blue preview and its distinct label, then that Secondary shows the purple preview and its distinct label.
+
+If native Studio-window inspection is unavailable, use the parent skill's embedded visual workflow. Treat client errors or a failure to mount the embedded UI as a visual-check failure, and stop play mode when finished.
+
+The semantic results remain authoritative for concrete Story selection because a screenshot cannot prove which Story id is active.

--- a/.github/MERGE_POLICY.md
+++ b/.github/MERGE_POLICY.md
@@ -1,0 +1,49 @@
+# Merge policy
+
+This policy describes who owns a change and what must happen before it merges. Repository instructions and automated checks implement this policy, but this document is the source of truth when they disagree.
+
+## Requirements for every pull request
+
+Every change merges through a pull request using the repository template. Greptile must report 5/5 for the current head commit.
+
+Greptile's required status is emitted by the review; it is not a separate review or charge. Each completed review counts as one Greptile review, including reviews automatically triggered by later commits. Batch related fixes when practical instead of creating review churn.
+
+A Greptile finding does not become correct merely because it is blocking. Authors may fix it, reply with relevant context and request another review, or ask an administrator to bypass the check. If Greptile retains the finding and no administrator bypasses it, the code must change before merge.
+
+## Ownership domains
+
+| Domain             | Responsibility                                                                                                                                                                 | Human approvals |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------: |
+| `flipbook-app`     | User-facing application structure, behavior, visual presentation, navigation, and Flipbook Next                                                                                |               1 |
+| `flipbook-engine`  | The runtime and build machinery that stands Flipbook up, including Storyteller, ModuleLoader, story loading and rendering, controls plumbing, and their integration boundaries |     0 (current) |
+| `flipbook-admins`  | Repository administration and catch-all stewardship across Flipbook Labs                                                                                                       |               0 |
+
+The live GitHub ruleset is the enforcement point for application and engine ownership. Its ownership paths and merge requirements are managed centrally in the [Flipbook Labs GitHub governance stack](https://github.com/flipbook-labs/infra/tree/main/stacks/github). Increase the engine team's minimum approval count to one when a second member joins.
+
+## Application review
+
+Any pull request touching an application-owned path requires approval from `@flipbook-labs/flipbook-app`. Application review covers the user-facing result rather than only the implementation. Include screenshots, video, or the pull request's Storybook preview when the change affects visible appearance or interaction.
+
+## Engine review
+
+Engine ownership currently identifies responsibility and requests visibility without requiring a human approval. While the engine team has one member, engine changes become mergeable when the required checks, including Greptile 5/5, pass for the current head commit. Once the team has more than one member, engine changes also require one engine-team approval.
+
+The administrator performing the merge remains responsible for the decision. Greptile does not merge pull requests and does not replace administrator judgment.
+
+## Mixed changes
+
+A pull request that touches both domains follows both paths and therefore requires application approval. Split a mixed change when the engine work is independently useful or when combining it with application work makes either responsibility harder to review. Do not split tightly coupled work solely to avoid application review.
+
+Some files necessarily mix integration and presentation. Keep those application-owned until their engine boundary is independently reviewable. Ownership follows the current responsibility of the file, not the name of an imported dependency.
+
+## Repository stewardship
+
+Administrative and stewardship changes belong to `@flipbook-labs/flipbook-admins`. This team has blanket permissions across Flipbook Labs and serves as the catch-all owner, but it has no path-based approval rule. A stewardship-only pull request therefore has no team-specific human approval requirement beyond the requirements for every pull request. If it also touches application- or engine-owned paths, those domain requirements still apply.
+
+## Administrator bypass
+
+Members of `@flipbook-labs/flipbook-admins` may bypass required reviews or status checks when exercising administrator judgment. A PR-body note or comment can preserve useful context, but a public explanation is not required. Agents must never bypass a merge requirement or recommend concealing a bypass.
+
+## Changing this policy
+
+Changes to this policy, the centrally managed ruleset, the pull request template, Greptile context, or the change-control skill belong to `@flipbook-labs/flipbook-admins`. Coordinate changes across Flipbook and the infrastructure repository so human guidance, agent guidance, and enforcement do not drift.

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,10 @@
+{
+  "context": {
+    "repos": [
+      "flipbook-labs/agent-skills",
+      "flipbook-labs/storyteller",
+      "flipbook-labs/module-loader"
+    ]
+  },
+  "statusCheck": true
+}

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,20 @@
+{
+  "files": [
+    {
+      "path": "AGENTS.md",
+      "description": "Repository-wide architecture, workflow, and agent instructions"
+    },
+    {
+      "path": ".github/MERGE_POLICY.md",
+      "description": "Authoritative ownership and merge requirements"
+    },
+    {
+      "path": ".agents/skills/README.md",
+      "description": "Trust and maintenance model for the vendored agent-skill library"
+    },
+    {
+      "path": ".agents/skills/flipbook-change-control/SKILL.md",
+      "description": "Pull request, review, and release workflow"
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ flipbook/
 └── .env / .env.template    # Environment variables (copy template to .env)
 ```
 
-Most application code lives under `workspace/flipbook-core/src/`, not `src/`. The root `src/init.server.luau` is only a thin bootstrap that calls `FlipbookCore.createFlipbookPlugin(...)`.
+Most application code lives under `workspace/flipbook-core/src/`, not `src/`. The root `src/` directory contains only thin plugin and embedded bootstraps; `src/PluginStarterScript.plugin.luau` delegates plugin startup to `FlipbookCore.createFlipbookPlugin(...)`.
 
 ### Storyteller / ModuleLoader
 
@@ -151,12 +151,12 @@ When editing or reviewing, treat surviving history-relative comments as litter t
 
 ### FlipbookCore vs the plugin shell
 
-- `src/init.server.luau` is minimal: it guards against non-edit mode, sets `_G.__DEV__` in dev builds, and delegates to `FlipbookCore.createFlipbookPlugin(plugin, widget, button)`.
+- `src/PluginStarterScript.plugin.luau` is minimal: it guards against non-edit mode, sets `_G.__DEV__` in dev builds, and delegates to `FlipbookCore.createFlipbookPlugin(plugin, widget, button)`.
 - All real functionality is in `workspace/flipbook-core/src/`. When working on Flipbook features, start there, not in `src/`.
 
 ### Charm flags workaround
 
-`src/init.server.luau` sets `Charm.flags.frozen = false`. This is a documented workaround for a Storyteller issue (issue #100). Do not remove it.
+`src/PluginStarterScript.plugin.luau` sets `Charm.flags.frozen = false`. This is a documented workaround for a Storyteller issue (issue #100). Do not remove it.
 
 ### Workspace members and production pruning
 
@@ -175,6 +175,14 @@ Source files use Luau-style aliases (`@pkg/`, `@workspace/`, `@repo/`, etc.). Da
 ---
 
 ## Project Skills
+
+Before preparing, reviewing, or merging a pull request, read [.github/MERGE_POLICY.md](.github/MERGE_POLICY.md) and `.agents/skills/flipbook-change-control/SKILL.md`. Ownership is inferred from changed files. Mixed application and engine changes require application review. Repository-stewardship changes belong to `@flipbook-labs/flipbook-admins` and have no separate human-approval requirement.
+
+Preserve `.github/pull_request_template.md` instead of replacing it with an agent-authored structure. For user-visible changes, include visual evidence that lets the application reviewer evaluate the result.
+
+Greptile must treat this file, `.github/MERGE_POLICY.md`, and the relevant vendored skills as authoritative repository guidance. The repositories listed in `.greptile/config.json` provide shared conventions and cross-repository implementation context. Keep `.greptile/files.json` limited to stable initial context, then follow this index and the changed code into specialized skills. When sources conflict, prefer this repository and then its vendored skills. Assess implementation safety independently from merge authorization: a change requiring human application approval is not inherently lower quality.
+
+Greptile findings must be evaluated rather than accepted mechanically. Fix valid findings. For an invalid finding, reply with concrete repository context and request another review. If Greptile still withholds the required 5/5 status, only a member of `@flipbook-labs/flipbook-admins` may bypass it; agents must not bypass merge requirements.
 
 Skill files live under `.agents/skills/<name>/SKILL.md`. Use them for conditional workflows and reference instead of keeping all details in always-loaded context. **Before starting work, scan this index; when a task matches a trigger, read that skill first.** Conventions, trust model, and maintenance norms are in [.agents/skills/README.md](.agents/skills/README.md) — the short version: skills are living documents, and when your work contradicts one you loaded, fix the skill in the same PR. This index is part of the library: update it in the same commit that adds, renames, or retires a skill.
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @flipbook-labs/flipbook-maintainers @flipbook-labs/flipbook-contributors

--- a/project.luau
+++ b/project.luau
@@ -7,7 +7,7 @@ return {
 	BUILD_CACHE_PATH = path.resolve("./build/build-cache.json"),
 	PACKAGES_PATH = path.resolve("./Packages"),
 	ROBLOX_PACKAGES_PATH = path.resolve("./RobloxPackages"),
-	ROBLOX_PACKAGES_VERSION = "0.733.0.7330989",
+	ROBLOX_PACKAGES_VERSION = "0.735.0.7351131",
 	SCRIPTS_PATH = path.resolve("./.lute"),
 	EXAMPLE_PATH = path.resolve("./example"),
 	WORKSPACE_PATH = path.resolve("./workspace"),

--- a/project.luau
+++ b/project.luau
@@ -7,7 +7,7 @@ return {
 	BUILD_CACHE_PATH = path.resolve("./build/build-cache.json"),
 	PACKAGES_PATH = path.resolve("./Packages"),
 	ROBLOX_PACKAGES_PATH = path.resolve("./RobloxPackages"),
-	ROBLOX_PACKAGES_VERSION = "0.735.0.7351131",
+	ROBLOX_PACKAGES_VERSION = "0.737.0.7371584",
 	SCRIPTS_PATH = path.resolve("./.lute"),
 	EXAMPLE_PATH = path.resolve("./example"),
 	WORKSPACE_PATH = path.resolve("./workspace"),

--- a/project.luau
+++ b/project.luau
@@ -7,7 +7,7 @@ return {
 	BUILD_CACHE_PATH = path.resolve("./build/build-cache.json"),
 	PACKAGES_PATH = path.resolve("./Packages"),
 	ROBLOX_PACKAGES_PATH = path.resolve("./RobloxPackages"),
-	ROBLOX_PACKAGES_VERSION = "0.715.1.7151119",
+	ROBLOX_PACKAGES_VERSION = "0.733.0.7330989",
 	SCRIPTS_PATH = path.resolve("./.lute"),
 	EXAMPLE_PATH = path.resolve("./example"),
 	WORKSPACE_PATH = path.resolve("./workspace"),


### PR DESCRIPTION
## Problem

The Studio MCP guidance mixes reusable AgentGateway validation with one multi-story fixture, making later scenarios depend on hard-coded paths and duplicate setup instructions.

## Solution

Keep the parent skill focused on connection, discovery, readiness polling, semantic evidence, and visual evidence. Move the multi-story fixture into a dedicated reference that:

- discovers Storybook and Story paths from gateway responses;
- opens Primary and Secondary by their concrete IDs;
- waits for mounted state and controls instead of sleeping;
- treats returned state as semantic proof and native Studio inspection as visual proof.

## Testing

Validated against the Storyteller companion branch in a built Storybook. Both Stories were discovered and opened, their IDs mounted independently, distinct control labels were read back, and the native Studio window showed the expected blue and purple previews.

## Notes for reviewers

Builds on: #624

Storyteller companion: https://github.com/flipbook-labs/storyteller/pull/153

Because #624 does not yet contain current `main`, this branch also carries the merged governance and package-version changes from `main`; those disappear from the stacked diff when the parent advances.

🤖 Generated with [Codex](https://openai.com/codex/)
