### PR TITLE
Set reasonable workflow timeouts

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,6 +43,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   publish-github-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
     if: ${{ github.event.release }}
@@ -43,7 +44,7 @@ jobs:
 
   publish-plugin:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     concurrency: production
     environment:
       name: roblox-creator-store
@@ -69,7 +70,7 @@ jobs:
 
   publish-nightly-plugin:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     concurrency: nightly
     environment:
       name: roblox-creator-store-dev


### PR DESCRIPTION
## Problem

Roblox publishing can legitimately exceed the existing five-minute job timeout while waiting for an Open Cloud execution. The [nightly publishing job](https://github.com/flipbook-labs/flipbook/actions/runs/34664598047/job/103473869258) in [run 34664598047](https://github.com/flipbook-labs/flipbook/actions/runs/34664598047) was canceled while it was still polling. Two GitHub-hosted deployment jobs also had no explicit timeout and therefore inherited the much larger platform default.

## Solution

- Give production and nightly Roblox publishing 15-minute ceilings.
- Give GitHub release publishing and Pages deployment 10-minute ceilings.
- Retain the existing shorter ceilings for fast, deterministic jobs.

## Testing

Validated that both edited workflow files parse as YAML and contain no whitespace errors.

## Notes for reviewers

The timeout values follow three tiers: five minutes for local build and automation jobs, 10 minutes for GitHub-hosted release and deployment work, and 15 minutes for Roblox-dependent publishing.