### PR TITLE
Connect Flipbook to agent controls

### DIFF
--- a/workspace/flipbook-core/.luaurc
+++ b/workspace/flipbook-core/.luaurc
@@ -3,6 +3,7 @@
 	"aliases": {
 		"pkg": "../../Packages",
 		"rbxpkg": "../../RobloxPackages",
-		"root": "./src"
+		"root": "./src",
+		"workspace": ".."
 	}
 }

--- a/workspace/flipbook-core/src/Agent/AgentContext.luau
+++ b/workspace/flipbook-core/src/Agent/AgentContext.luau
@@ -1,0 +1,16 @@
+local React = require("@pkg/React")
+
+local FlipbookAgents = require("@workspace/flipbook-agents/src")
+
+type AgentController = FlipbookAgents.AgentController
+
+local Context = React.createContext(nil :: AgentController?)
+
+local function use(): AgentController?
+	return React.useContext(Context)
+end
+
+return {
+	Provider = Context.Provider,
+	use = use,
+}

--- a/workspace/flipbook-core/src/Agent/createAppImplementation.luau
+++ b/workspace/flipbook-core/src/Agent/createAppImplementation.luau
@@ -1,0 +1,103 @@
+local Storyteller = require("@pkg/Storyteller")
+
+local FlipbookAgents = require("@workspace/flipbook-agents/src")
+local getInstanceFromPath = require("@root/Common/getInstanceFromPath")
+local getInstancePath = require("@root/Common/getInstancePath")
+
+type AppImplementation = FlipbookAgents.AppImplementation
+type StorybookInfo = FlipbookAgents.StorybookInfo
+type StoryInfo = FlipbookAgents.StoryInfo
+type LoadedStorybook = Storyteller.LoadedStorybook
+type UnavailableStorybook = Storyteller.UnavailableStorybook
+
+type Storybooks = {
+	available: { LoadedStorybook },
+	unavailable: { UnavailableStorybook },
+}
+
+export type Options = {
+	getStorybooks: () -> Storybooks,
+	getCurrentStory: () -> (ModuleScript?, LoadedStorybook?),
+	openStory: (ModuleScript, LoadedStorybook?) -> (),
+}
+
+local function serializeStorybook(storybook: LoadedStorybook): StorybookInfo
+	return {
+		name = storybook.name,
+		path = getInstancePath(storybook.source),
+	}
+end
+
+local function serializeStory(story: ModuleScript, storybook: LoadedStorybook?): StoryInfo
+	return {
+		name = story.Name:gsub("%.story$", ""),
+		path = getInstancePath(story),
+		storybook = if storybook then getInstancePath(storybook.source) else nil,
+	}
+end
+
+local function resolveModuleScript(path: string, label: string): ModuleScript
+	local instance = getInstanceFromPath(path)
+	if instance == nil then
+		error(`{label} not found at path: {path}`)
+	end
+	if not instance:IsA("ModuleScript") then
+		error(`{label} must be a ModuleScript: {path}`)
+	end
+	return instance
+end
+
+local function createAppImplementation(options: Options): AppImplementation
+	local function findStorybook(storybookPath: string): LoadedStorybook
+		for _, storybook in options.getStorybooks().available do
+			if getInstancePath(storybook.source) == storybookPath then
+				return storybook
+			end
+		end
+		error(`storybook is unavailable: {storybookPath}`)
+	end
+
+	local function findStorybookForStory(story: ModuleScript): LoadedStorybook?
+		for _, storybook in options.getStorybooks().available do
+			for _, storyRoot in storybook.storyRoots do
+				if storyRoot == story or storyRoot:IsAncestorOf(story) then
+					return storybook
+				end
+			end
+		end
+		return nil
+	end
+
+	return {
+		listStorybooks = function()
+			local result = {}
+			for _, storybook in options.getStorybooks().available do
+				table.insert(result, serializeStorybook(storybook))
+			end
+			return result
+		end,
+
+		listStories = function(storybookPath: string)
+			local storybook = findStorybook(storybookPath)
+			local result = {}
+			for _, story in Storyteller.findStoryModulesForStorybook(storybook) do
+				table.insert(result, serializeStory(story, storybook))
+			end
+			return result
+		end,
+
+		openStory = function(storyPath: string, storybookPath: string?)
+			local story = resolveModuleScript(storyPath, "story")
+			local storybook = if storybookPath then findStorybook(storybookPath) else findStorybookForStory(story)
+			options.openStory(story, storybook)
+			return serializeStory(story, storybook)
+		end,
+
+		getCurrentStory = function()
+			local story, storybook = options.getCurrentStory()
+			return if story then serializeStory(story, storybook) else nil
+		end,
+	}
+end
+
+return createAppImplementation

--- a/workspace/flipbook-core/src/Agent/createAppImplementation.spec.luau
+++ b/workspace/flipbook-core/src/Agent/createAppImplementation.spec.luau
@@ -1,0 +1,86 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local JestGlobals = require("@pkg/JestGlobals")
+local Storyteller = require("@pkg/Storyteller")
+
+local createAppImplementation = require("@root/Agent/createAppImplementation")
+local getInstancePath = require("@root/Common/getInstancePath")
+
+local afterEach = JestGlobals.afterEach
+local beforeEach = JestGlobals.beforeEach
+local expect = JestGlobals.expect
+local test = JestGlobals.test
+
+local root: Folder
+local story: ModuleScript
+local storybookModule: ModuleScript
+local storybook: Storyteller.LoadedStorybook
+local openedStory: ModuleScript?
+
+beforeEach(function()
+	root = Instance.new("Folder")
+	root.Name = "AgentAppImplementationSpec"
+	root.Parent = ReplicatedStorage
+
+	storybookModule = Instance.new("ModuleScript")
+	storybookModule.Name = "Example.storybook"
+	storybookModule.Parent = root
+
+	local stories = Instance.new("Folder")
+	stories.Name = "Stories"
+	stories.Parent = root
+
+	story = Instance.new("ModuleScript")
+	story.Name = "Button.story"
+	story.Parent = stories
+
+	storybook = {
+		name = "Example",
+		source = storybookModule,
+		storyRoots = { stories :: Instance },
+	}
+	openedStory = nil
+end)
+
+afterEach(function()
+	root:Destroy()
+end)
+
+local function createImplementation()
+	return createAppImplementation({
+		getStorybooks = function()
+			return { available = { storybook }, unavailable = {} }
+		end,
+		getCurrentStory = function()
+			return openedStory, if openedStory then storybook else nil
+		end,
+		openStory = function(nextStory)
+			openedStory = nextStory
+		end,
+	})
+end
+
+test("discovers Storybooks and their Stories without fixed DataModel paths", function()
+	local implementation = createImplementation()
+
+	expect(implementation.listStorybooks()).toEqual({
+		{ name = "Example", path = getInstancePath(storybookModule) },
+	})
+	expect(implementation.listStories(getInstancePath(storybookModule))).toEqual({
+		{
+			name = "Button",
+			path = getInstancePath(story),
+			storybook = getInstancePath(storybookModule),
+		},
+	})
+end)
+
+test("opens a discovered Story and reports it as current", function()
+	local implementation = createImplementation()
+
+	local result = implementation.openStory(getInstancePath(story), getInstancePath(storybookModule))
+
+	expect(result.path).toBe(getInstancePath(story))
+	expect(openedStory).toBe(story)
+	expect(implementation.getCurrentStory()).toEqual(result)
+end)

--- a/workspace/flipbook-core/src/Common/ContextProviders.luau
+++ b/workspace/flipbook-core/src/Common/ContextProviders.luau
@@ -2,8 +2,10 @@ local Foundation = require("@rbxpkg/Foundation")
 local React = require("@pkg/React")
 local Storyteller = require("@pkg/Storyteller")
 
+local AgentContext = require("@root/Agent/AgentContext")
 local CommonTypes = require("@root/Common/types")
 local ContextStack = require("@root/Common/ContextStack")
+local FlipbookAgents = require("@workspace/flipbook-agents/src")
 local NavigationContext = require("@root/Navigation/NavigationContext")
 local PluginStore = require("@root/Plugin/PluginStore")
 local useThemeName = require("@root/Common/useThemeName")
@@ -11,11 +13,13 @@ local useThemeName = require("@root/Common/useThemeName")
 local useEffect = React.useEffect
 
 type Pluginlike = CommonTypes.Pluginlike
+type AgentController = FlipbookAgents.AgentController
 
 export type Props = {
 	plugin: Pluginlike,
 	theme: Foundation.Theme?,
 	overlayGui: GuiBase2d?,
+	agentController: AgentController?,
 	children: React.Node?,
 }
 
@@ -28,6 +32,9 @@ local function ContextProviders(props: Props)
 
 	return React.createElement(ContextStack, {
 		providers = {
+			React.createElement(AgentContext.Provider, {
+				value = props.agentController,
+			}),
 			React.createElement(Foundation.FoundationProvider, {
 				theme = props.theme or themeName,
 				overlayGui = props.overlayGui,

--- a/workspace/flipbook-core/src/FlipbookApp.luau
+++ b/workspace/flipbook-core/src/FlipbookApp.luau
@@ -3,6 +3,7 @@ local React = require("@pkg/React")
 local ReactCharm = require("@pkg/ReactCharm")
 local Storyteller = require("@pkg/Storyteller")
 
+local AgentContext = require("@root/Agent/AgentContext")
 local AppMode = require("@root/Enums/AppMode")
 local BuildChannel = require("@root/Enums/BuildChannel")
 local BuildTarget = require("@root/Enums/BuildTarget")
@@ -15,6 +16,7 @@ local TelemetryOptOutDialog = require("@root/Telemetry/TelemetryOptOutDialog")
 local Topbar = require("@root/Panels/Topbar")
 local UserSettingsStore = require("@root/UserSettings/UserSettingsStore")
 local constants = require("@root/constants")
+local createAppImplementation = require("@root/Agent/createAppImplementation")
 local createLoadedStorybook = require("@root/Storybook/createLoadedStorybook")
 local fireEventAsync = require("@root/Telemetry/fireEventAsync")
 local nextLayoutOrder = require("@root/Common/nextLayoutOrder")
@@ -32,14 +34,24 @@ export type Props = {
 }
 
 local function FlipbookApp(props: Props)
+	local agentController = AgentContext.use()
 	local userSettingsStore = useSignalState(UserSettingsStore.get)
 	local userSettings = useSignalState(userSettingsStore.getStorage)
+	local storybooks = Storyteller.useStorybooks()
 
 	local storyModule: ModuleScript?, setStoryModule = React.useState(nil :: ModuleScript?)
 	local storybook, setStorybook = React.useState(nil :: LoadedStorybook?)
 	local unavailableStorybook: UnavailableStorybook?, setUnavailableStorybook =
 		React.useState(nil :: UnavailableStorybook?)
 	local navigation = NavigationContext.use()
+	local latest = React.useRef({
+		storyModule = storyModule,
+		storybook = storybook,
+		storybooks = storybooks,
+	})
+	latest.current.storyModule = storyModule
+	latest.current.storybook = storybook
+	latest.current.storybooks = storybooks
 
 	local onStoryChanged = React.useCallback(function(newStoryModule: ModuleScript?, newStorybook: LoadedStorybook?)
 		navigation.navigateTo("Home")
@@ -65,6 +77,22 @@ local function FlipbookApp(props: Props)
 		setStorybook(nil)
 		setUnavailableStorybook(newUnavailableStorybook)
 	end, {})
+
+	React.useEffect(function()
+		if agentController == nil then
+			return
+		end
+
+		return agentController.registerApp(createAppImplementation({
+			getStorybooks = function()
+				return latest.current.storybooks
+			end,
+			getCurrentStory = function()
+				return latest.current.storyModule, latest.current.storybook
+			end,
+			openStory = onStoryChanged,
+		}))
+	end, { agentController, onStoryChanged } :: { unknown })
 
 	return React.createElement(Foundation.View, {
 		tag = "size-full row align-y-center flex-between",

--- a/workspace/flipbook-core/src/Plugin/createFlipbookPlugin.luau
+++ b/workspace/flipbook-core/src/Plugin/createFlipbookPlugin.luau
@@ -1,4 +1,5 @@
 local AppMode = require("@root/Enums/AppMode")
+local FlipbookAgents = require("@workspace/flipbook-agents/src")
 local createFlipbookApp = require("@root/createFlipbookApp")
 
 local CommonTypes = require("@root/Common/types")
@@ -7,10 +8,13 @@ type Pluginlike = CommonTypes.Pluginlike
 
 local function createFlipbookPlugin(plugin: Pluginlike, widget: DockWidgetPluginGui, button: PluginToolbarButton?)
 	local connections: { RBXScriptConnection } = {}
+	local agentController = FlipbookAgents.createAgentController(widget)
+	local cleanupAgentGateway = FlipbookAgents.createAgentGateway(agentController)
 	local app = createFlipbookApp(widget, {
 		plugin = plugin,
 		overlayGui = widget :: GuiBase2d,
 		mode = AppMode.PluginWidget,
+		agentController = agentController,
 	})
 
 	if button ~= nil then
@@ -45,6 +49,7 @@ local function createFlipbookPlugin(plugin: Pluginlike, widget: DockWidgetPlugin
 	end
 
 	local function destroy()
+		cleanupAgentGateway()
 		app.destroy()
 
 		for _, connection in connections do

--- a/workspace/flipbook-core/src/Storybook/StoryView.luau
+++ b/workspace/flipbook-core/src/Storybook/StoryView.luau
@@ -3,11 +3,14 @@ local React = require("@pkg/React")
 local ReactCharm = require("@pkg/ReactCharm")
 local Storyteller = require("@pkg/Storyteller")
 
+local AgentContext = require("@root/Agent/AgentContext")
 local PluginStore = require("@root/Plugin/PluginStore")
 local StoryControlsContext = require("@root/StoryControls/StoryControlsContext")
 local StoryControlsPanel = require("@root/StoryControls/StoryControlsPanel")
 local StoryError = require("@root/Storybook/StoryError")
 local StoryPreview = require("@root/Storybook/StoryPreview")
+local createStoryControlsStore = require("@root/StoryControls/createStoryControlsStore")
+local getInstancePath = require("@root/Common/getInstancePath")
 local types = require("@root/Storybook/types")
 local useThemeName = require("@root/Common/useThemeName")
 
@@ -16,6 +19,7 @@ local Text = Foundation.Text
 local View = Foundation.View
 
 local e = React.createElement
+local useEffect = React.useEffect
 local useMemo = React.useMemo
 local useSignalState = ReactCharm.useSignalState
 local useStory = Storyteller.useStory
@@ -23,6 +27,7 @@ local useOverlay = Foundation.Hooks.useOverlay
 
 type LoadedStorybook = Storyteller.LoadedStorybook
 type ExtraStoryProps = types.ExtraStoryProps
+type StoryControlsStore = createStoryControlsStore.StoryControlsStore
 
 type StoryViewProps = {
 	storyModule: ModuleScript,
@@ -30,11 +35,33 @@ type StoryViewProps = {
 }
 
 local function StoryView(props: StoryViewProps)
+	local agentController = AgentContext.use()
 	local story, storyError = useStory(props.storyModule, props.storybook)
 	local theme = useThemeName()
 	local pluginStore = useSignalState(PluginStore.get)
 	local plugin = useSignalState(pluginStore.getPlugin)
 	local overlayGui = useOverlay()
+	local storyControlsStore = useMemo(function(): StoryControlsStore?
+		return if story then createStoryControlsStore(story.controls) else nil
+	end, { story } :: { unknown })
+
+	useEffect(function()
+		if agentController == nil or storyControlsStore == nil then
+			return
+		end
+		return agentController.registerStory({
+			path = getInstancePath(props.storyModule),
+			getControls = function()
+				return storyControlsStore.getControls() :: any
+			end,
+			setControls = function(controls)
+				for key, value in controls do
+					storyControlsStore.setControl(key, value :: any)
+				end
+				return storyControlsStore.getControls() :: any
+			end,
+		})
+	end, { agentController, props.storyModule, storyControlsStore } :: { unknown })
 
 	local extraProps = useMemo(function(): ExtraStoryProps
 		return {
@@ -49,6 +76,7 @@ local function StoryView(props: StoryViewProps)
 		StoryControlsContext.StoryControlsProvider,
 		{
 			schema = story and story.controls or nil,
+			store = storyControlsStore,
 		},
 		e(View, {
 			tag = "size-full bg-surface-200",

--- a/workspace/flipbook-core/src/createFlipbookApp.luau
+++ b/workspace/flipbook-core/src/createFlipbookApp.luau
@@ -4,17 +4,20 @@ local ReactRoblox = require("@pkg/ReactRoblox")
 local AppMode = require("@root/Enums/AppMode")
 local CommonTypes = require("@root/Common/types")
 local ContextProviders = require("@root/Common/ContextProviders")
+local FlipbookAgents = require("@workspace/flipbook-agents/src")
 local FlipbookApp = require("@root/FlipbookApp")
 local fireEventAsync = require("@root/Telemetry/fireEventAsync")
 local logger = require("@root/logger")
 
 type AppMode = AppMode.AppMode
+type AgentController = FlipbookAgents.AgentController
 type Pluginlike = CommonTypes.Pluginlike
 
 export type Options = {
 	plugin: Pluginlike?,
 	overlayGui: GuiBase2d?,
 	mode: AppMode?,
+	agentController: AgentController?,
 }
 
 local defaultPlugin: Pluginlike = {
@@ -45,6 +48,7 @@ local function createFlipbookApp(container: GuiBase2d, options: Options?)
 	local app = React.createElement(ContextProviders, {
 		plugin = appOptions.plugin or defaultPlugin,
 		overlayGui = appOptions.overlayGui or container,
+		agentController = appOptions.agentController,
 	}, {
 		FlipbookApp = React.createElement(FlipbookApp, {
 			mode = appOptions.mode,


### PR DESCRIPTION
## Problem

Flipbook needs a small app-owned adapter before Studio agents can use the reusable control runtime from #635.

## Solution

Connect the plugin lifecycle to `flipbook-agents`, adapt Storyteller discovery to the package contract, and expose each mounted story's existing controls store through the agent controller.

## Testing

The app adapter has focused discovery and navigation specs. The integration also passes lint, static analysis, and a clean plugin build.

## Notes for reviewers

Builds on: #635

Blocks: #636

🤖 Generated with [Codex](https://openai.com/codex/)
