### PR TITLE
Add dual-runtime Storybook previews

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -12,7 +12,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
   actions: write
 
 jobs:
@@ -45,13 +44,17 @@ jobs:
       - name: Build storybook place
         run: lute run build storybook
 
-      # On `main` we build a fresh Flipbook.rbxm off the branch and use it as the
-      # runtime, so we catch embedding issues before cutting a release. PR builds
-      # skip this so a PR's own UI changes don't pollute the app underneath its
-      # preview (the deploy-storybook action fetches the latest release instead).
       - name: Build Flipbook runtime
-        if: github.event_name == 'push'
         run: lute run build plugin --channel prod --skip-reload --clean
+
+      - name: Generate preview app token
+        if: github.event_name == 'pull_request'
+        id: preview-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.FLIPBOOK_PREVIEW_APP_ID }}
+          private-key: ${{ secrets.FLIPBOOK_PREVIEW_APP_PRIVATE_KEY }}
+          permission-pull-requests: write
 
       - name: Deploy main storybook
         if: github.event_name == 'push'
@@ -67,10 +70,11 @@ jobs:
 
       - name: Deploy PR storybook
         if: github.event_name == 'pull_request'
-        uses: flipbook-labs/deploy-storybook@v0.4.0
+        uses: flipbook-labs/deploy-storybook@da5abf27b6f38556ba5fb4cdef896f27be9dd77f
         with:
           api-key: ${{ secrets.ROBLOX_STORYBOOK_PREVIEW_API_KEY }}
           universe-id: ${{ steps.ids.outputs.universe-id }}
           place-name: ${{ env.PREVIEW_PLACE_NAME }}
           place-file: build/flipbook-storybook.rbxl
-          cli-version: "0.6.0"
+          current-flipbook-rbxm: build/prod/Flipbook.rbxm
+          github-token: ${{ steps.preview-app-token.outputs.token }}

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Deploy PR storybook
         if: github.event_name == 'pull_request'
-        uses: flipbook-labs/deploy-storybook@da5abf27b6f38556ba5fb4cdef896f27be9dd77f
+        uses: flipbook-labs/deploy-storybook@10df0500439611dd21b42f7188c23854afacf3bf
         with:
           api-key: ${{ secrets.ROBLOX_STORYBOOK_PREVIEW_API_KEY }}
           universe-id: ${{ steps.ids.outputs.universe-id }}

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -52,7 +52,7 @@ jobs:
         id: preview-app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.FLIPBOOK_PREVIEW_APP_ID }}
+          client-id: ${{ secrets.FLIPBOOK_PREVIEW_APP_CLIENT_ID }}
           private-key: ${{ secrets.FLIPBOOK_PREVIEW_APP_PRIVATE_KEY }}
           permission-pull-requests: write
 


### PR DESCRIPTION
## Problem

Pull request Storybook previews use the latest Flipbook release, so package upgrades and other changes to Flipbook itself cannot be smoke-tested through the preview. Preview comments also appear under the generic GitHub Actions identity.

## Solution

- Build the pull request's production Flipbook runtime alongside its Storybook place.
- Deploy the latest release and pull request runtimes to separate places through one action invocation.
- Authenticate comments as a dedicated Flipbook Preview GitHub App with pull-request write permission.

## Testing

Built the Storybook place and production Flipbook runtime locally. The live comparison deploy depends on the action and CLI releases below.

## Notes for reviewers

Depends on: flipbook-labs/deploy-storybook#28
Depends on: flipbook-labs/flipbook-cli#61

Before merge, replace the pinned action commit with its release tag and configure the `FLIPBOOK_PREVIEW_APP_CLIENT_ID` and `FLIPBOOK_PREVIEW_APP_PRIVATE_KEY` secrets in the `storybook-preview` environment. The app needs Metadata read and Pull requests write access to this repository.

🤖 Generated with Codex.